### PR TITLE
Add monthly shop reset notification preference

### DIFF
--- a/app/db/postgres/schema.ts
+++ b/app/db/postgres/schema.ts
@@ -202,7 +202,12 @@ export const pgTimelineContentsTable = pgTable(
 );
 
 export type DiscordConnectionStatus = "pending" | "active" | "failed";
-export type DiscordNotificationTrigger = "event-start" | "event-end" | "reward-exchange-end" | "recruitment-start";
+export type DiscordNotificationTrigger =
+  | "event-start"
+  | "event-end"
+  | "reward-exchange-end"
+  | "recruitment-start"
+  | "shop-reset";
 export type DiscordNotificationJobTrigger = DiscordNotificationTrigger | "connection-verification";
 
 export type NotificationChannelType = "discord";

--- a/app/domain/discord-notifications.ts
+++ b/app/domain/discord-notifications.ts
@@ -7,6 +7,7 @@ export const DISCORD_NOTIFICATION_DEFAULTS = {
   eventEndEnabled: false,
   rewardExchangeEndEnabled: false,
   recruitmentStartEnabled: false,
+  shopResetEnabled: false,
   leadHours: 24,
 };
 
@@ -40,6 +41,7 @@ export type DiscordNotificationSettingsInput = {
   eventEndEnabled: boolean;
   rewardExchangeEndEnabled: boolean;
   recruitmentStartEnabled: boolean;
+  shopResetEnabled: boolean;
   leadHours: number;
 };
 
@@ -145,6 +147,8 @@ export function formatDiscordNotificationMessage({
     return `${at}, ${names.map((name) => `"${name}"`).join(", ")} 학생의 모집이 시작됩니다.`;
   }
 
+  if (trigger === "shop-reset") return `${at}, 상점이 초기화됩니다.`;
+
   const name = requireName(contentName);
   switch (trigger) {
     case "event-start":
@@ -162,5 +166,6 @@ export function getEnabledTriggers(settings: DiscordNotificationSettingsInput): 
     settings.eventEndEnabled ? "event-end" : null,
     settings.rewardExchangeEndEnabled ? "reward-exchange-end" : null,
     settings.recruitmentStartEnabled ? "recruitment-start" : null,
+    settings.shopResetEnabled ? "shop-reset" : null,
   ].filter((trigger): trigger is DiscordNotificationTrigger => trigger !== null);
 }

--- a/app/models/discord-notifications.server.ts
+++ b/app/models/discord-notifications.server.ts
@@ -20,7 +20,8 @@ type DiscordNotificationSettingsKey =
   | "eventStartEnabled"
   | "eventEndEnabled"
   | "rewardExchangeEndEnabled"
-  | "recruitmentStartEnabled";
+  | "recruitmentStartEnabled"
+  | "shopResetEnabled";
 
 const PREFERENCE_KEYS: ReadonlyArray<{
   type: DiscordNotificationTrigger;
@@ -30,6 +31,7 @@ const PREFERENCE_KEYS: ReadonlyArray<{
   { type: "event-end", key: "eventEndEnabled" },
   { type: "reward-exchange-end", key: "rewardExchangeEndEnabled" },
   { type: "recruitment-start", key: "recruitmentStartEnabled" },
+  { type: "shop-reset", key: "shopResetEnabled" },
 ];
 
 export type DiscordConnection = {
@@ -132,6 +134,7 @@ function mapPreferences(rows: readonly QueryRow[], now: Date): MappedPreferences
     eventEndEnabled: byType.get("event-end")?.enabled ?? false,
     rewardExchangeEndEnabled: byType.get("reward-exchange-end")?.enabled ?? false,
     recruitmentStartEnabled: byType.get("recruitment-start")?.enabled ?? false,
+    shopResetEnabled: byType.get("shop-reset")?.enabled ?? false,
     leadHours: resolvedLeadHours,
     effectiveAt: (effectiveAt ?? now).toISOString(),
   };
@@ -149,6 +152,7 @@ export function parseDiscordNotificationSettingsForm(formData: FormData): Discor
     eventEndEnabled: booleanValue("eventEndEnabled"),
     rewardExchangeEndEnabled: booleanValue("rewardExchangeEndEnabled"),
     recruitmentStartEnabled: booleanValue("recruitmentStartEnabled"),
+    shopResetEnabled: booleanValue("shopResetEnabled"),
     leadHours: Number(leadHoursValue ?? Number.NaN),
   };
   return validateDiscordNotificationSettings(input);

--- a/app/routes/notifications._components/NotificationPreferencesCard.tsx
+++ b/app/routes/notifications._components/NotificationPreferencesCard.tsx
@@ -47,10 +47,7 @@ export default function NotificationPreferencesCard({
   };
 
   return (
-    <SectionCard
-      title="받을 알림"
-      description="알림은 수 분 정도 지연이 발생할 수 있어요"
-    >
+    <SectionCard title="받을 알림" description="알림은 수 분 정도 지연이 발생할 수 있어요">
       {error ? <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p> : null}
       <Form method="post" onChange={markDirty}>
         <input type="hidden" name="intent" value="save" />
@@ -108,6 +105,18 @@ export default function NotificationPreferencesCard({
                 <Toggle
                   name="recruitmentStartEnabled"
                   initialState={settings.recruitmentStartEnabled}
+                  className="my-0 shrink-0"
+                  onChange={markDirty}
+                />
+              </div>
+              <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                <div className="min-w-0">
+                  <p className="text-sm">상점 초기화 알림</p>
+                  <p className="text-xs text-muted-foreground">매월 1일 상점 초기화 알림</p>
+                </div>
+                <Toggle
+                  name="shopResetEnabled"
+                  initialState={settings.shopResetEnabled}
                   className="my-0 shrink-0"
                   onChange={markDirty}
                 />

--- a/test/app/domain/discord-notifications.test.ts
+++ b/test/app/domain/discord-notifications.test.ts
@@ -40,6 +40,15 @@ describe("Discord notification timing and copy", () => {
     ).toBe('9/7(월) 11:00, "XXX", "YYY" 학생의 모집이 시작됩니다.');
   });
 
+  it("formats the monthly shop reset message from its KST source anchor", () => {
+    expect(
+      formatDiscordNotificationMessage({
+        trigger: "shop-reset",
+        sourceAnchor: "2026-08-31T19:00:00.000Z",
+      }),
+    ).toBe("9/1(화) 04:00, 상점이 초기화됩니다.");
+  });
+
   it("blocks missing names rather than using an internal uid", () => {
     expect(() =>
       formatDiscordNotificationMessage({ trigger: "event-end", sourceAnchor: new Date(), contentName: null }),

--- a/test/app/models/discord-notifications.test.ts
+++ b/test/app/models/discord-notifications.test.ts
@@ -24,22 +24,25 @@ function preferenceRows(leadHours = 24, effectiveAt = existingEffectiveAt) {
     { notification_type: "event-end", enabled: false, lead_hours: leadHours, effective_at: effectiveAt },
     { notification_type: "reward-exchange-end", enabled: false, lead_hours: leadHours, effective_at: effectiveAt },
     { notification_type: "recruitment-start", enabled: false, lead_hours: leadHours, effective_at: effectiveAt },
+    { notification_type: "shop-reset", enabled: false, lead_hours: leadHours, effective_at: effectiveAt },
   ];
 }
 
 describe("Discord notification settings boundary", () => {
-  it("validates explicit settings and all four independent trigger values", () => {
+  it("validates explicit settings and all five independent trigger values", () => {
     const form = new FormData();
     form.set("eventStartEnabled", "true");
     form.set("eventEndEnabled", "false");
     form.set("rewardExchangeEndEnabled", "true");
     form.set("recruitmentStartEnabled", "false");
+    form.set("shopResetEnabled", "true");
     form.set("leadHours", "23");
     expect(parseDiscordNotificationSettingsForm(form)).toEqual({
       eventStartEnabled: true,
       eventEndEnabled: false,
       rewardExchangeEndEnabled: true,
       recruitmentStartEnabled: false,
+      shopResetEnabled: true,
       leadHours: 23,
     });
   });
@@ -81,7 +84,7 @@ describe("Discord notification settings boundary", () => {
     expect(statements.some((statement) => statement.startsWith("delete from notification_preferences"))).toBe(false);
   });
 
-  it("writes the shared lead time to all four preference rows transactionally", async () => {
+  it("writes the shared lead time to all five preference rows transactionally", async () => {
     const statements: string[] = [];
     const insertValues: unknown[][] = [];
     const client = {
@@ -92,7 +95,7 @@ describe("Discord notification settings boundary", () => {
           return { rows: [{ status: "active" }], rowCount: 1 };
         }
         if (normalized.startsWith("select notification_type")) {
-          return { rows: preferenceRows(), rowCount: 4 };
+          return { rows: preferenceRows(), rowCount: 5 };
         }
         if (normalized.startsWith("insert into notification_preferences")) {
           insertValues.push([...values]);
@@ -110,6 +113,7 @@ describe("Discord notification settings boundary", () => {
         eventEndEnabled: true,
         rewardExchangeEndEnabled: false,
         recruitmentStartEnabled: false,
+        shopResetEnabled: false,
         leadHours: 12,
       },
       { now: () => laterEffectiveAt },
@@ -121,7 +125,14 @@ describe("Discord notification settings boundary", () => {
       1,
     );
     expect(insertValues[0]).toEqual(
-      expect.arrayContaining(["event-start", "event-end", "reward-exchange-end", "recruitment-start", 12]),
+      expect.arrayContaining([
+        "event-start",
+        "event-end",
+        "reward-exchange-end",
+        "recruitment-start",
+        "shop-reset",
+        12,
+      ]),
     );
   });
 
@@ -146,9 +157,47 @@ describe("Discord notification settings boundary", () => {
         eventEndEnabled: false,
         rewardExchangeEndEnabled: false,
         recruitmentStartEnabled: false,
+        shopResetEnabled: false,
         leadHours: 24,
       }),
     ).rejects.toThrow(DiscordNotificationSettingsInconsistentError);
+  });
+
+  it("creates a missing shop reset row on the next explicit save", async () => {
+    const insertValues: unknown[][] = [];
+    const client = {
+      async query(text: string, values: readonly unknown[] = []) {
+        const normalized = text.replace(/\s+/g, " ").trim();
+        if (normalized.startsWith("select status from notification_channels")) {
+          return { rows: [{ status: "active" }], rowCount: 1 };
+        }
+        if (normalized.startsWith("select notification_type")) {
+          return { rows: preferenceRows().slice(0, 4), rowCount: 4 };
+        }
+        if (normalized.startsWith("insert into notification_preferences")) {
+          insertValues.push([...values]);
+        }
+        return { rows: [], rowCount: 1 };
+      },
+    };
+    const env = { __pgClient: client } as unknown as Env;
+
+    await saveDiscordNotificationSettings(
+      env,
+      7,
+      {
+        eventStartEnabled: true,
+        eventEndEnabled: false,
+        rewardExchangeEndEnabled: false,
+        recruitmentStartEnabled: false,
+        shopResetEnabled: true,
+        leadHours: 24,
+      },
+      { now: () => laterEffectiveAt },
+    );
+
+    expect(insertValues).toHaveLength(1);
+    expect(insertValues[0]).toEqual(expect.arrayContaining(["shop-reset", true, 24, laterEffectiveAt]));
   });
 
   it("creates the Discord login identity and pending channel in one ownership transaction", async () => {
@@ -241,6 +290,29 @@ describe("Discord notification settings boundary", () => {
     expect(connection).toBeNull();
   });
 
+  it("defaults a missing shop reset preference to disabled", async () => {
+    const client = {
+      async query(text: string) {
+        const normalized = text.replace(/\s+/g, " ").trim();
+        if (normalized.startsWith("select status from notification_channels")) {
+          return { rows: [{ status: "active" }], rowCount: 1 };
+        }
+        if (normalized.startsWith("select notification_type")) {
+          return { rows: preferenceRows().slice(0, 4), rowCount: 4 };
+        }
+        return { rows: [], rowCount: 0 };
+      },
+    };
+    const env = { __pgClient: client } as unknown as Env;
+
+    const state = await getDiscordNotificationState(env, 7, {
+      now: () => new Date("2026-09-01T00:00:00.000Z"),
+    });
+
+    expect(state.settings.shopResetEnabled).toBe(false);
+    expect(state.settings.leadHours).toBe(24);
+  });
+
   it("does not expose the Discord recipient key in notification state", async () => {
     const client = {
       async query(text: string) {
@@ -249,7 +321,7 @@ describe("Discord notification settings boundary", () => {
           return { rows: [{ status: "active", recipient_key: "1234567890" }], rowCount: 1 };
         }
         if (normalized.startsWith("select notification_type")) {
-          return { rows: preferenceRows(), rowCount: 4 };
+          return { rows: preferenceRows(), rowCount: 5 };
         }
         return { rows: [], rowCount: 0 };
       },


### PR DESCRIPTION
## Summary

Add a monthly shop reset notification preference so users can opt in to alerts anchored at 04:00 KST on the first day of each month.

## Changes

- Add the shop-reset trigger to the typed notification preference contract.
- Default missing shop-reset preferences to disabled and upsert them with the shared lead-time and effective-time semantics.
- Add the exact shop reset toggle name and description as the final preference row.
- Cover message formatting, missing-row defaults, and explicit-save persistence with focused tests.

## Verification

- [x] I verified the related behavior myself.
- [x] I ran pnpm typecheck, pnpm run lint, and relevant tests when needed.
- [ ] (If AI tools were used) The generated content was reviewed by a person.

Focused verification: 3 Jest suites and 22 tests passed. Typecheck, lint, and git diff checks passed. Lint reported only pre-existing diagnostics outside the changed paths.

## Related issues

- [MLLG-9](https://linear.app/dtrippers/issue/MLLG-9/알림-유형-추가)