### PR TITLE
Persist student filters without hydration flicker

### DIFF
--- a/app/components/features/students/StudentFilter.tsx
+++ b/app/components/features/students/StudentFilter.tsx
@@ -72,6 +72,14 @@ const tacticRoleFilterOptions = [
   { text: "T.S.", value: "tactical_support" as const },
 ];
 
+export const STUDENT_FILTER_OPTION_VALUES = {
+  attackTypes: attackFilterOptions.map(({ value }) => value),
+  defenseTypes: defenseFilterOptions.map(({ value }) => value),
+  roles: roleFilterOptions.map(({ value }) => value),
+  positions: positionFilterOptions.map(({ value }) => value),
+  tacticRoles: tacticRoleFilterOptions.map(({ value }) => value),
+} as const;
+
 const sortFilterOptions: Record<SortBy, string> = {
   recent: "최신순",
   old: "과거순",
@@ -121,7 +129,13 @@ export default function StudentFilter({
     [controlledState, onStateChange, state],
   );
 
-  const [localSearch, setLocalSearch] = useState("");
+  const controlledSearch = controlledState?.search;
+  const isControlled = controlledState !== undefined;
+  const [localSearch, setLocalSearch] = useState(() => controlledSearch ?? "");
+
+  useEffect(() => {
+    setLocalSearch(isControlled ? (controlledSearch ?? "") : "");
+  }, [controlledSearch, isControlled]);
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/app/components/features/students/StudentFilter.tsx
+++ b/app/components/features/students/StudentFilter.tsx
@@ -8,7 +8,7 @@ import {
 } from "@heroicons/react/24/outline";
 import hangul from "hangul-js";
 import { useCallback, useEffect, useState } from "react";
-import { PanelBody, PanelFilterButtonRow, PanelSearchField } from "~/components/primitives";
+import { Button, PanelBody, PanelFilterButtonRow, PanelSearchField } from "~/components/primitives";
 import { Attack, Defense } from "~/graphql/graphql";
 import { defenseTypeShortLocale } from "~/locales/ko";
 import type { Position, Role, TacticRole } from "~/models/content.d";
@@ -95,6 +95,24 @@ export function createStudentFilterState(sort: SortBy = "recent"): StudentFilter
     tacticRoles: [],
     positions: [],
     sort,
+  };
+}
+
+export function hasActiveStudentFilters(state: StudentFilterState): boolean {
+  return Boolean(
+    state.search ||
+      state.attackTypes.length ||
+      state.defenseTypes.length ||
+      state.roles.length ||
+      state.tacticRoles.length ||
+      state.positions.length,
+  );
+}
+
+export function clearStudentFilters(state: StudentFilterState): StudentFilterState {
+  return {
+    ...createStudentFilterState(state.sort),
+    search: "",
   };
 }
 
@@ -253,6 +271,16 @@ export default function StudentFilter({
           size="sm"
         />
       )}
+      {hasActiveStudentFilters(state) ? (
+        <div className="flex justify-end pt-1">
+          <Button
+            text="필터 해제"
+            size="xs"
+            variant="danger-subtle"
+            onClick={() => setFilterState(clearStudentFilters)}
+          />
+        </div>
+      ) : null}
     </PanelBody>
   );
 }

--- a/app/components/features/students/index.ts
+++ b/app/components/features/students/index.ts
@@ -1,16 +1,20 @@
 export { default as RecruitmentHistories } from "./RecruitmentHistories";
-export { default as ResourceCards } from "./ResourceCards";
 export type { ResourceCardsProps } from "./ResourceCards";
-export { default as StudentCard } from "./StudentCard";
-export { StudentCardPopup } from "./StudentCard";
+export { default as ResourceCards } from "./ResourceCards";
+export { default as StudentCard, StudentCardPopup } from "./StudentCard";
 export { default as StudentCards } from "./StudentCards";
-export { default as StudentFilter } from "./StudentFilter";
-export { applyStudentFilter, createStudentFilterState, getFilteredStudentUids } from "./StudentFilter";
 export type { SortBy, StudentFilterState } from "./StudentFilter";
-export { default as StudentGradingTimeline } from "./StudentGradingTimeline";
-export { formatStudentGradingTimestamp } from "./StudentGradingTimeline";
+export {
+  applyStudentFilter,
+  createStudentFilterState,
+  default as StudentFilter,
+  getFilteredStudentUids,
+} from "./StudentFilter";
 export type { StudentGradingTimelineItem } from "./StudentGradingTimeline";
+export { default as StudentGradingTimeline, formatStudentGradingTimestamp } from "./StudentGradingTimeline";
 export { default as StudentInfo } from "./StudentInfo";
 export { default as StudentSearchInput } from "./StudentSearchInput";
 export { default as TierCounts } from "./TierCounts";
 export { default as TierSelector } from "./TierSelector";
+export type { PersistentStudentFilterStateOptions } from "./usePersistentStudentFilterState";
+export { usePersistentStudentFilterState } from "./usePersistentStudentFilterState";

--- a/app/components/features/students/student-filter-cookie.ts
+++ b/app/components/features/students/student-filter-cookie.ts
@@ -1,0 +1,169 @@
+import {
+  createStudentFilterState,
+  type SortBy,
+  STUDENT_FILTER_OPTION_VALUES,
+  type StudentFilterState,
+} from "./StudentFilter";
+
+export type StudentFilterStateNormalizationOptions = {
+  defaultSort: SortBy;
+  allowedSorts: readonly SortBy[];
+};
+
+export type StudentFilterCookieOptions = StudentFilterStateNormalizationOptions & {
+  cookieName: string;
+  cookiePath: string;
+};
+
+export const MAX_STUDENT_FILTER_COOKIE_SIZE = 2048;
+export const STUDENT_FILTER_COOKIE_MAX_AGE = 400 * 24 * 60 * 60;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function filterKnownValues<T extends string>(value: unknown, allowedValues: readonly T[]): T[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const allowed = new Set(allowedValues);
+  const seen = new Set<T>();
+  return value.filter((item): item is T => {
+    if (typeof item !== "string" || !allowed.has(item as T) || seen.has(item as T)) {
+      return false;
+    }
+    seen.add(item as T);
+    return true;
+  });
+}
+
+function getDefaultSort({ defaultSort, allowedSorts }: StudentFilterStateNormalizationOptions): SortBy {
+  return allowedSorts.includes(defaultSort) ? defaultSort : "recent";
+}
+
+function createDefaultStudentFilterState(options: StudentFilterStateNormalizationOptions): StudentFilterState {
+  return createStudentFilterState(getDefaultSort(options));
+}
+
+export function normalizeStudentFilterState(
+  value: unknown,
+  options: StudentFilterStateNormalizationOptions,
+): StudentFilterState {
+  const defaults = createDefaultStudentFilterState(options);
+  if (!isRecord(value)) {
+    return defaults;
+  }
+
+  const normalized: StudentFilterState = {
+    ...defaults,
+    attackTypes: filterKnownValues(value.attackTypes, STUDENT_FILTER_OPTION_VALUES.attackTypes),
+    defenseTypes: filterKnownValues(value.defenseTypes, STUDENT_FILTER_OPTION_VALUES.defenseTypes),
+    roles: filterKnownValues(value.roles, STUDENT_FILTER_OPTION_VALUES.roles),
+    tacticRoles: filterKnownValues(value.tacticRoles, STUDENT_FILTER_OPTION_VALUES.tacticRoles),
+    positions: filterKnownValues(value.positions, STUDENT_FILTER_OPTION_VALUES.positions),
+  };
+
+  if (options.allowedSorts.includes(value.sort as SortBy)) {
+    normalized.sort = value.sort as SortBy;
+  }
+
+  return normalized;
+}
+
+type PersistedStudentFilterState = Pick<
+  StudentFilterState,
+  "attackTypes" | "defenseTypes" | "roles" | "tacticRoles" | "positions" | "sort"
+>;
+
+function toPersistedStudentFilterState(state: StudentFilterState): PersistedStudentFilterState {
+  return {
+    attackTypes: state.attackTypes,
+    defenseTypes: state.defenseTypes,
+    roles: state.roles,
+    tacticRoles: state.tacticRoles,
+    positions: state.positions,
+    sort: state.sort,
+  };
+}
+
+function getCookieValue(cookieHeader: string | null, cookieName: string): string | null {
+  if (!cookieHeader) {
+    return null;
+  }
+
+  for (const cookie of cookieHeader.split(";")) {
+    const separatorIndex = cookie.indexOf("=");
+    if (separatorIndex < 0 || cookie.slice(0, separatorIndex).trim() !== cookieName) {
+      continue;
+    }
+    return cookie.slice(separatorIndex + 1).trim();
+  }
+
+  return null;
+}
+
+export function readStudentFilterStateFromCookie(
+  cookieHeader: string | null,
+  options: StudentFilterCookieOptions,
+): StudentFilterState {
+  const defaults = createDefaultStudentFilterState(options);
+  const encodedValue = getCookieValue(cookieHeader, options.cookieName);
+  if (!encodedValue || encodedValue.length > MAX_STUDENT_FILTER_COOKIE_SIZE) {
+    return defaults;
+  }
+
+  try {
+    return normalizeStudentFilterState(JSON.parse(decodeURIComponent(encodedValue)), options);
+  } catch {
+    return defaults;
+  }
+}
+
+export function serializeStudentFilterStateCookie(
+  options: StudentFilterStateNormalizationOptions,
+  state: StudentFilterState,
+): string | null {
+  try {
+    const normalized = normalizeStudentFilterState(state, options);
+    const serialized = encodeURIComponent(JSON.stringify(toPersistedStudentFilterState(normalized)));
+    return serialized.length <= MAX_STUDENT_FILTER_COOKIE_SIZE ? serialized : null;
+  } catch {
+    return null;
+  }
+}
+
+function isHttps(): boolean {
+  try {
+    return typeof location !== "undefined" && location.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function getBrowserDocument(): Document | null {
+  try {
+    return typeof document === "undefined" ? null : document;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStudentFilterStateCookie(options: StudentFilterCookieOptions, state: StudentFilterState): void {
+  const browserDocument = getBrowserDocument();
+  if (!browserDocument) {
+    return;
+  }
+
+  const serialized = serializeStudentFilterStateCookie(options, state);
+  if (!serialized) {
+    return;
+  }
+
+  try {
+    const secure = isHttps() ? "; Secure" : "";
+    browserDocument.cookie = `${options.cookieName}=${serialized}; Path=${options.cookiePath}; Max-Age=${STUDENT_FILTER_COOKIE_MAX_AGE}; SameSite=Lax${secure}`;
+  } catch {
+    // Keep the student list usable when browser cookies are unavailable.
+  }
+}

--- a/app/components/features/students/usePersistentStudentFilterState.ts
+++ b/app/components/features/students/usePersistentStudentFilterState.ts
@@ -1,0 +1,142 @@
+import { useEffect, useState } from "react";
+import {
+  createStudentFilterState,
+  type SortBy,
+  STUDENT_FILTER_OPTION_VALUES,
+  type StudentFilterState,
+} from "./StudentFilter";
+
+export type PersistentStudentFilterStateOptions = {
+  storageKey: string;
+  defaultSort: SortBy;
+  allowedSorts: readonly SortBy[];
+};
+
+type StudentFilterStateNormalizationOptions = Pick<PersistentStudentFilterStateOptions, "defaultSort" | "allowedSorts">;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function filterKnownValues<T extends string>(value: unknown, allowedValues: readonly T[]): T[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const allowed = new Set(allowedValues);
+  const seen = new Set<T>();
+  return value.filter((item): item is T => {
+    if (typeof item !== "string" || !allowed.has(item as T) || seen.has(item as T)) {
+      return false;
+    }
+    seen.add(item as T);
+    return true;
+  });
+}
+
+function getDefaultSort({ defaultSort, allowedSorts }: StudentFilterStateNormalizationOptions): SortBy {
+  return allowedSorts.includes(defaultSort) ? defaultSort : "recent";
+}
+
+function createDefaultStudentFilterState(options: StudentFilterStateNormalizationOptions): StudentFilterState {
+  return createStudentFilterState(getDefaultSort(options));
+}
+
+export function normalizeStudentFilterState(
+  value: unknown,
+  options: StudentFilterStateNormalizationOptions,
+): StudentFilterState {
+  const defaults = createDefaultStudentFilterState(options);
+  if (!isRecord(value)) {
+    return defaults;
+  }
+
+  const normalized: StudentFilterState = {
+    ...defaults,
+    attackTypes: filterKnownValues(value.attackTypes, STUDENT_FILTER_OPTION_VALUES.attackTypes),
+    defenseTypes: filterKnownValues(value.defenseTypes, STUDENT_FILTER_OPTION_VALUES.defenseTypes),
+    roles: filterKnownValues(value.roles, STUDENT_FILTER_OPTION_VALUES.roles),
+    tacticRoles: filterKnownValues(value.tacticRoles, STUDENT_FILTER_OPTION_VALUES.tacticRoles),
+    positions: filterKnownValues(value.positions, STUDENT_FILTER_OPTION_VALUES.positions),
+  };
+
+  if (options.allowedSorts.includes(value.sort as SortBy)) {
+    normalized.sort = value.sort as SortBy;
+  }
+  if (typeof value.search === "string") {
+    normalized.search = value.search;
+  }
+
+  return normalized;
+}
+
+function getBrowserStorage(): Storage | null {
+  try {
+    return typeof globalThis.localStorage === "undefined" ? null : globalThis.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function readStudentFilterState(options: PersistentStudentFilterStateOptions): StudentFilterState {
+  const defaults = createDefaultStudentFilterState(options);
+  const storage = getBrowserStorage();
+  if (!storage) {
+    return defaults;
+  }
+
+  try {
+    const saved = storage.getItem(options.storageKey);
+    return saved ? normalizeStudentFilterState(JSON.parse(saved), options) : defaults;
+  } catch {
+    return defaults;
+  }
+}
+
+function toPersistedStudentFilterState(state: StudentFilterState): StudentFilterState {
+  return {
+    attackTypes: state.attackTypes,
+    defenseTypes: state.defenseTypes,
+    roles: state.roles,
+    tacticRoles: state.tacticRoles,
+    positions: state.positions,
+    ...(state.sort === undefined ? {} : { sort: state.sort }),
+    ...(state.search === undefined ? {} : { search: state.search }),
+  };
+}
+
+export function writeStudentFilterState(options: PersistentStudentFilterStateOptions, state: StudentFilterState): void {
+  const storage = getBrowserStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    const normalized = normalizeStudentFilterState(state, options);
+    storage.setItem(options.storageKey, JSON.stringify(toPersistedStudentFilterState(normalized)));
+  } catch {
+    // Keep the student list usable when browser storage is unavailable.
+  }
+}
+
+export function usePersistentStudentFilterState(options: PersistentStudentFilterStateOptions) {
+  const { allowedSorts, defaultSort, storageKey } = options;
+  const [state, setState] = useState<StudentFilterState>(() => createDefaultStudentFilterState(options));
+  const [hydratedStorageKey, setHydratedStorageKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    setHydratedStorageKey(null);
+    setState(readStudentFilterState({ storageKey, defaultSort, allowedSorts }));
+    setHydratedStorageKey(storageKey);
+  }, [allowedSorts, defaultSort, storageKey]);
+
+  useEffect(() => {
+    if (hydratedStorageKey !== storageKey) {
+      return;
+    }
+
+    writeStudentFilterState({ storageKey, defaultSort, allowedSorts }, state);
+  }, [allowedSorts, defaultSort, hydratedStorageKey, state, storageKey]);
+
+  return [state, setState] as const;
+}

--- a/app/components/features/students/usePersistentStudentFilterState.ts
+++ b/app/components/features/students/usePersistentStudentFilterState.ts
@@ -1,142 +1,38 @@
-import { useEffect, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { createStudentFilterState, type StudentFilterState } from "./StudentFilter";
 import {
-  createStudentFilterState,
-  type SortBy,
-  STUDENT_FILTER_OPTION_VALUES,
-  type StudentFilterState,
-} from "./StudentFilter";
+  normalizeStudentFilterState,
+  type StudentFilterCookieOptions,
+  serializeStudentFilterStateCookie,
+  writeStudentFilterStateCookie,
+} from "./student-filter-cookie";
 
-export type PersistentStudentFilterStateOptions = {
-  storageKey: string;
-  defaultSort: SortBy;
-  allowedSorts: readonly SortBy[];
+export type PersistentStudentFilterStateOptions = StudentFilterCookieOptions & {
+  initialState?: StudentFilterState;
 };
 
-type StudentFilterStateNormalizationOptions = Pick<PersistentStudentFilterStateOptions, "defaultSort" | "allowedSorts">;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function filterKnownValues<T extends string>(value: unknown, allowedValues: readonly T[]): T[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  const allowed = new Set(allowedValues);
-  const seen = new Set<T>();
-  return value.filter((item): item is T => {
-    if (typeof item !== "string" || !allowed.has(item as T) || seen.has(item as T)) {
-      return false;
-    }
-    seen.add(item as T);
-    return true;
-  });
-}
-
-function getDefaultSort({ defaultSort, allowedSorts }: StudentFilterStateNormalizationOptions): SortBy {
-  return allowedSorts.includes(defaultSort) ? defaultSort : "recent";
-}
-
-function createDefaultStudentFilterState(options: StudentFilterStateNormalizationOptions): StudentFilterState {
-  return createStudentFilterState(getDefaultSort(options));
-}
-
-export function normalizeStudentFilterState(
-  value: unknown,
-  options: StudentFilterStateNormalizationOptions,
-): StudentFilterState {
-  const defaults = createDefaultStudentFilterState(options);
-  if (!isRecord(value)) {
-    return defaults;
-  }
-
-  const normalized: StudentFilterState = {
-    ...defaults,
-    attackTypes: filterKnownValues(value.attackTypes, STUDENT_FILTER_OPTION_VALUES.attackTypes),
-    defenseTypes: filterKnownValues(value.defenseTypes, STUDENT_FILTER_OPTION_VALUES.defenseTypes),
-    roles: filterKnownValues(value.roles, STUDENT_FILTER_OPTION_VALUES.roles),
-    tacticRoles: filterKnownValues(value.tacticRoles, STUDENT_FILTER_OPTION_VALUES.tacticRoles),
-    positions: filterKnownValues(value.positions, STUDENT_FILTER_OPTION_VALUES.positions),
-  };
-
-  if (options.allowedSorts.includes(value.sort as SortBy)) {
-    normalized.sort = value.sort as SortBy;
-  }
-  if (typeof value.search === "string") {
-    normalized.search = value.search;
-  }
-
-  return normalized;
-}
-
-function getBrowserStorage(): Storage | null {
-  try {
-    return typeof globalThis.localStorage === "undefined" ? null : globalThis.localStorage;
-  } catch {
-    return null;
-  }
-}
-
-export function readStudentFilterState(options: PersistentStudentFilterStateOptions): StudentFilterState {
-  const defaults = createDefaultStudentFilterState(options);
-  const storage = getBrowserStorage();
-  if (!storage) {
-    return defaults;
-  }
-
-  try {
-    const saved = storage.getItem(options.storageKey);
-    return saved ? normalizeStudentFilterState(JSON.parse(saved), options) : defaults;
-  } catch {
-    return defaults;
-  }
-}
-
-function toPersistedStudentFilterState(state: StudentFilterState): StudentFilterState {
-  return {
-    attackTypes: state.attackTypes,
-    defenseTypes: state.defenseTypes,
-    roles: state.roles,
-    tacticRoles: state.tacticRoles,
-    positions: state.positions,
-    ...(state.sort === undefined ? {} : { sort: state.sort }),
-    ...(state.search === undefined ? {} : { search: state.search }),
-  };
-}
-
-export function writeStudentFilterState(options: PersistentStudentFilterStateOptions, state: StudentFilterState): void {
-  const storage = getBrowserStorage();
-  if (!storage) {
-    return;
-  }
-
-  try {
-    const normalized = normalizeStudentFilterState(state, options);
-    storage.setItem(options.storageKey, JSON.stringify(toPersistedStudentFilterState(normalized)));
-  } catch {
-    // Keep the student list usable when browser storage is unavailable.
-  }
-}
-
 export function usePersistentStudentFilterState(options: PersistentStudentFilterStateOptions) {
-  const { allowedSorts, defaultSort, storageKey } = options;
-  const [state, setState] = useState<StudentFilterState>(() => createDefaultStudentFilterState(options));
-  const [hydratedStorageKey, setHydratedStorageKey] = useState<string | null>(null);
+  const { allowedSorts, cookieName, cookiePath, defaultSort, initialState } = options;
+  const normalizationOptions = useMemo(() => ({ defaultSort, allowedSorts }), [allowedSorts, defaultSort]);
+  const [state, setState] = useState<StudentFilterState>(() =>
+    normalizeStudentFilterState(initialState ?? createStudentFilterState(defaultSort), normalizationOptions),
+  );
+  const stateRef = useRef(state);
+  const serializedStateRef = useRef(serializeStudentFilterStateCookie(normalizationOptions, state));
 
-  useEffect(() => {
-    setHydratedStorageKey(null);
-    setState(readStudentFilterState({ storageKey, defaultSort, allowedSorts }));
-    setHydratedStorageKey(storageKey);
-  }, [allowedSorts, defaultSort, storageKey]);
+  const setPersistentState = useCallback(
+    (updater: React.SetStateAction<StudentFilterState>) => {
+      const nextState = typeof updater === "function" ? updater(stateRef.current) : updater;
+      stateRef.current = nextState;
+      const serializedState = serializeStudentFilterStateCookie(normalizationOptions, nextState);
+      if (serializedState !== serializedStateRef.current) {
+        writeStudentFilterStateCookie({ cookieName, cookiePath, defaultSort, allowedSorts }, nextState);
+        serializedStateRef.current = serializedState;
+      }
+      setState(nextState);
+    },
+    [allowedSorts, cookieName, cookiePath, defaultSort, normalizationOptions],
+  );
 
-  useEffect(() => {
-    if (hydratedStorageKey !== storageKey) {
-      return;
-    }
-
-    writeStudentFilterState({ storageKey, defaultSort, allowedSorts }, state);
-  }, [allowedSorts, defaultSort, hydratedStorageKey, state, storageKey]);
-
-  return [state, setState] as const;
+  return [state, setPersistentState] as const;
 }

--- a/app/routes/$username.students.tsx
+++ b/app/routes/$username.students.tsx
@@ -295,7 +295,7 @@ export default function UserPage() {
           onStateChange={setFilterState}
           useFilter
           useSearch
-          sortBy={["recent", "old", "name", "tier"]}
+          sortBy={[...USER_STUDENT_FILTER_SORTS]}
         />
       ),
     });

--- a/app/routes/$username.students.tsx
+++ b/app/routes/$username.students.tsx
@@ -11,11 +11,11 @@ import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react
 import { data, useFetcher, useLoaderData, useOutletContext } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import {
-  createStudentFilterState,
   getFilteredStudentUids,
   StudentCards,
   StudentFilter,
   TierSelector,
+  usePersistentStudentFilterState,
 } from "~/components/features/students";
 import { Button, SubTitle, Toggle } from "~/components/primitives";
 import { captureServerError, getLogger } from "~/lib/observability.server";
@@ -30,6 +30,9 @@ import {
 } from "~/models/recruited-student";
 import { getAllStudents, getAllStudentsMap } from "~/models/student";
 import { getRouteSensei } from "./$username._components/route-sensei.server";
+
+const USER_STUDENT_FILTER_STORAGE_KEY = "mollulog::user-students::view-settings";
+const USER_STUDENT_FILTER_SORTS = ["recent", "old", "name", "tier"] as const;
 
 export const loader = async ({ context, request, params }: LoaderFunctionArgs) => {
   const { env, ctx } = context.cloudflare;
@@ -257,7 +260,11 @@ export default function UserPage() {
   const loaderData = useLoaderData<typeof loader>();
   const { me, noRecruited, students } = loaderData;
 
-  const [filterState, setFilterState] = useState(() => createStudentFilterState("recent"));
+  const [filterState, setFilterState] = usePersistentStudentFilterState({
+    storageKey: USER_STUDENT_FILTER_STORAGE_KEY,
+    defaultSort: "recent",
+    allowedSorts: USER_STUDENT_FILTER_SORTS,
+  });
   const filteredUids = useMemo(() => getFilteredStudentUids(students, filterState), [students, filterState]);
   const studentMap = useMemo(() => new Map(students.map((student) => [student.uid, student])), [students]);
   const [recruitedStudents, unrecruitedStudents] = useMemo(() => {
@@ -292,7 +299,7 @@ export default function UserPage() {
         />
       ),
     });
-  }, [filterState, students, setPanel]);
+  }, [filterState, students, setPanel, setFilterState]);
 
   const [batchAddMode, setBatchAddMode] = useState(false);
   const [batchAddStudentUids, setBatchAddStudentUids] = useState<string[]>([]);

--- a/app/routes/$username.students.tsx
+++ b/app/routes/$username.students.tsx
@@ -295,7 +295,7 @@ export default function UserPage() {
   useEffect(() => {
     setPanel({
       title: "필터 및 정렬",
-      description: "학생을 필터링하고 정렬할 수 있어요.",
+      description: `${students.length}명 중 ${filteredUids.length}명 표시 중`,
       Icon: FunnelIcon,
       children: (
         <StudentFilter
@@ -308,7 +308,7 @@ export default function UserPage() {
         />
       ),
     });
-  }, [filterState, students, setPanel, setFilterState]);
+  }, [filterState, students, setPanel, setFilterState, filteredUids.length]);
 
   const [batchAddMode, setBatchAddMode] = useState(false);
   const [batchAddStudentUids, setBatchAddStudentUids] = useState<string[]>([]);

--- a/app/routes/$username.students.tsx
+++ b/app/routes/$username.students.tsx
@@ -17,6 +17,7 @@ import {
   TierSelector,
   usePersistentStudentFilterState,
 } from "~/components/features/students";
+import { readStudentFilterStateFromCookie } from "~/components/features/students/student-filter-cookie";
 import { Button, SubTitle, Toggle } from "~/components/primitives";
 import { captureServerError, getLogger } from "~/lib/observability.server";
 import {
@@ -31,8 +32,16 @@ import {
 import { getAllStudents, getAllStudentsMap } from "~/models/student";
 import { getRouteSensei } from "./$username._components/route-sensei.server";
 
-const USER_STUDENT_FILTER_STORAGE_KEY = "mollulog::user-students::view-settings";
-const USER_STUDENT_FILTER_SORTS = ["recent", "old", "name", "tier"] as const;
+export const USER_STUDENT_FILTER_COOKIE_NAME = "mollulog_user_students_filter";
+export const USER_STUDENT_FILTER_COOKIE_PATH = "/";
+export const USER_STUDENT_FILTER_SORTS = ["recent", "old", "name", "tier"] as const;
+
+const userStudentFilterCookieOptions = {
+  cookieName: USER_STUDENT_FILTER_COOKIE_NAME,
+  cookiePath: USER_STUDENT_FILTER_COOKIE_PATH,
+  defaultSort: "recent",
+  allowedSorts: USER_STUDENT_FILTER_SORTS,
+} as const;
 
 export const loader = async ({ context, request, params }: LoaderFunctionArgs) => {
   const { env, ctx } = context.cloudflare;
@@ -52,6 +61,7 @@ export const loader = async ({ context, request, params }: LoaderFunctionArgs) =
   return {
     me: currentUser?.username === sensei.username,
     noRecruited: recruitedStudents.length === 0,
+    filterState: readStudentFilterStateFromCookie(request.headers.get("Cookie"), userStudentFilterCookieOptions),
     students: allStudents.map((student) => ({
       uid: student.uid,
       name: student.name,
@@ -258,12 +268,11 @@ export const action = async ({ context, request, params }: ActionFunctionArgs) =
 
 export default function UserPage() {
   const loaderData = useLoaderData<typeof loader>();
-  const { me, noRecruited, students } = loaderData;
+  const { filterState: initialFilterState, me, noRecruited, students } = loaderData;
 
   const [filterState, setFilterState] = usePersistentStudentFilterState({
-    storageKey: USER_STUDENT_FILTER_STORAGE_KEY,
-    defaultSort: "recent",
-    allowedSorts: USER_STUDENT_FILTER_SORTS,
+    ...userStudentFilterCookieOptions,
+    initialState: initialFilterState,
   });
   const filteredUids = useMemo(() => getFilteredStudentUids(students, filterState), [students, filterState]);
   const studentMap = useMemo(() => new Map(students.map((student) => [student.uid, student])), [students]);

--- a/app/routes/students.tsx
+++ b/app/routes/students.tsx
@@ -80,7 +80,7 @@ export default function StudentsLayout() {
                     students={students}
                     state={filterState}
                     onStateChange={setFilterState}
-                    sortBy={["recent", "old", "name"]}
+                    sortBy={[...STUDENT_FILTER_SORTS]}
                     useFilter
                     useSearch
                   />

--- a/app/routes/students.tsx
+++ b/app/routes/students.tsx
@@ -4,20 +4,31 @@ import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { Outlet, useLoaderData, useLocation } from "react-router";
 import { Page } from "~/components/features/layout";
 import { getFilteredStudentUids, StudentFilter, usePersistentStudentFilterState } from "~/components/features/students";
+import { readStudentFilterStateFromCookie } from "~/components/features/students/student-filter-cookie";
 import { canonicalLink } from "~/lib/seo";
 import { getAllStudents } from "~/models/student";
 
-const STUDENT_FILTER_STORAGE_KEY = "mollulog::students::view-settings";
-const STUDENT_FILTER_SORTS = ["recent", "old", "name"] as const;
+export const STUDENT_FILTER_COOKIE_NAME = "mollulog_students_filter";
+export const STUDENT_FILTER_COOKIE_PATH = "/students";
+export const STUDENT_FILTER_SORTS = ["recent", "old", "name"] as const;
+
+const studentFilterCookieOptions = {
+  cookieName: STUDENT_FILTER_COOKIE_NAME,
+  cookiePath: STUDENT_FILTER_COOKIE_PATH,
+  defaultSort: "recent",
+  allowedSorts: STUDENT_FILTER_SORTS,
+} as const;
 
 export const loader = async ({ context, request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
   const pathname = url.pathname;
   const needsStudentList = pathname === "/students";
+  const filterState = readStudentFilterStateFromCookie(request.headers.get("Cookie"), studentFilterCookieOptions);
 
   if (!needsStudentList) {
     return {
       students: [],
+      filterState,
     };
   }
 
@@ -25,6 +36,7 @@ export const loader = async ({ context, request }: LoaderFunctionArgs) => {
   const allStudents = await getAllStudents(env, true);
   return {
     students: allStudents.sort((a, b) => b.order - a.order),
+    filterState,
   };
 };
 
@@ -43,14 +55,13 @@ export const meta: MetaFunction = ({ location }) => {
 };
 
 export default function StudentsLayout() {
-  const { students } = useLoaderData<typeof loader>();
+  const { filterState: initialFilterState, students } = useLoaderData<typeof loader>();
   const { pathname } = useLocation();
   const usesStudentsPageLayout = pathname === "/students" || pathname === "/students/gradings";
   const studentMap = useMemo(() => new Map(students.map((student) => [student.uid, student])), [students]);
   const [filterState, setFilterState] = usePersistentStudentFilterState({
-    storageKey: STUDENT_FILTER_STORAGE_KEY,
-    defaultSort: "recent",
-    allowedSorts: STUDENT_FILTER_SORTS,
+    ...studentFilterCookieOptions,
+    initialState: initialFilterState,
   });
   const filteredUids = useMemo(() => getFilteredStudentUids(students, filterState), [students, filterState]);
   const filteredStudents = useMemo(() => {

--- a/app/routes/students.tsx
+++ b/app/routes/students.tsx
@@ -1,11 +1,14 @@
 import { ChatBubbleLeftRightIcon, FunnelIcon, IdentificationIcon, VideoCameraIcon } from "@heroicons/react/24/outline";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { Outlet, useLoaderData, useLocation } from "react-router";
 import { Page } from "~/components/features/layout";
-import { createStudentFilterState, getFilteredStudentUids, StudentFilter } from "~/components/features/students";
+import { getFilteredStudentUids, StudentFilter, usePersistentStudentFilterState } from "~/components/features/students";
 import { canonicalLink } from "~/lib/seo";
 import { getAllStudents } from "~/models/student";
+
+const STUDENT_FILTER_STORAGE_KEY = "mollulog::students::view-settings";
+const STUDENT_FILTER_SORTS = ["recent", "old", "name"] as const;
 
 export const loader = async ({ context, request }: LoaderFunctionArgs) => {
   const url = new URL(request.url);
@@ -44,7 +47,11 @@ export default function StudentsLayout() {
   const { pathname } = useLocation();
   const usesStudentsPageLayout = pathname === "/students" || pathname === "/students/gradings";
   const studentMap = useMemo(() => new Map(students.map((student) => [student.uid, student])), [students]);
-  const [filterState, setFilterState] = useState(() => createStudentFilterState("recent"));
+  const [filterState, setFilterState] = usePersistentStudentFilterState({
+    storageKey: STUDENT_FILTER_STORAGE_KEY,
+    defaultSort: "recent",
+    allowedSorts: STUDENT_FILTER_SORTS,
+  });
   const filteredUids = useMemo(() => getFilteredStudentUids(students, filterState), [students, filterState]);
   const filteredStudents = useMemo(() => {
     return filteredUids.flatMap((uid) => {

--- a/app/routes/students.tsx
+++ b/app/routes/students.tsx
@@ -9,7 +9,7 @@ import { canonicalLink } from "~/lib/seo";
 import { getAllStudents } from "~/models/student";
 
 export const STUDENT_FILTER_COOKIE_NAME = "mollulog_students_filter";
-export const STUDENT_FILTER_COOKIE_PATH = "/students";
+export const STUDENT_FILTER_COOKIE_PATH = "/";
 export const STUDENT_FILTER_SORTS = ["recent", "old", "name"] as const;
 
 const studentFilterCookieOptions = {
@@ -85,6 +85,7 @@ export default function StudentsLayout() {
           ? [
               {
                 title: "필터 및 정렬",
+                description: `${students.length}명 중 ${filteredStudents.length}명 표시 중`,
                 Icon: FunnelIcon,
                 children: (
                   <StudentFilter

--- a/test/app/components/features/students/persistent-student-filter-state.test.ts
+++ b/test/app/components/features/students/persistent-student-filter-state.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { createStudentFilterState, type StudentFilterState } from "~/components/features/students/StudentFilter";
+import {
+  normalizeStudentFilterState,
+  type PersistentStudentFilterStateOptions,
+  readStudentFilterState,
+  writeStudentFilterState,
+} from "~/components/features/students/usePersistentStudentFilterState";
+import { Attack, Defense } from "~/graphql/graphql";
+
+const generalOptions: PersistentStudentFilterStateOptions = {
+  storageKey: "mollulog::students::view-settings",
+  defaultSort: "recent",
+  allowedSorts: ["recent", "old", "name"],
+};
+
+const userOptions: PersistentStudentFilterStateOptions = {
+  storageKey: "mollulog::user-students::view-settings",
+  defaultSort: "recent",
+  allowedSorts: ["recent", "old", "name", "tier"],
+};
+
+function createStorage(initial: Record<string, string> = {}) {
+  const values = new Map(Object.entries(initial));
+  const getItem = jest.fn((key: string) => values.get(key) ?? null);
+  const setItem = jest.fn((key: string, value: string) => {
+    values.set(key, value);
+  });
+
+  return {
+    storage: { getItem, setItem } as unknown as Storage,
+    getItem,
+    setItem,
+  };
+}
+
+let localStorageDescriptor: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  localStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+});
+
+afterEach(() => {
+  if (localStorageDescriptor) {
+    Object.defineProperty(globalThis, "localStorage", localStorageDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "localStorage");
+  }
+});
+
+function installStorage(storage: Storage) {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+}
+
+describe("persistent student filter state", () => {
+  it("normalizes each field without discarding valid values from other fields", () => {
+    const normalized = normalizeStudentFilterState(
+      {
+        attackTypes: [Attack.Explosive, "retired-attack", 1],
+        defenseTypes: "heavy",
+        roles: ["special", "retired-role"],
+        positions: ["back", "retired-position"],
+        tacticRoles: ["healer", "retired-tactic-role"],
+        sort: "old",
+        search: 42,
+      },
+      generalOptions,
+    );
+
+    expect(normalized).toEqual({
+      ...createStudentFilterState("old"),
+      attackTypes: [Attack.Explosive],
+      roles: ["special"],
+      positions: ["back"],
+      tacticRoles: ["healer"],
+    });
+  });
+
+  it("falls back to the screen default for an unsupported sort", () => {
+    const normalized = normalizeStudentFilterState({ sort: "tier", search: "아루" }, generalOptions);
+
+    expect(normalized).toEqual({
+      ...createStudentFilterState("recent"),
+      search: "아루",
+    });
+  });
+
+  it("accepts tier sorting on the user student screen", () => {
+    expect(normalizeStudentFilterState({ sort: "tier" }, userOptions)).toEqual(createStudentFilterState("tier"));
+  });
+
+  it("keeps general and user student preferences under independent keys", () => {
+    const storage = createStorage();
+    installStorage(storage.storage);
+    const generalState: StudentFilterState = {
+      ...createStudentFilterState("name"),
+      attackTypes: [Attack.Explosive],
+      search: "아루",
+    };
+    const userState: StudentFilterState = {
+      ...createStudentFilterState("tier"),
+      defenseTypes: [Defense.Heavy],
+      search: "시로코",
+    };
+
+    writeStudentFilterState(generalOptions, generalState);
+    writeStudentFilterState(userOptions, userState);
+
+    expect(readStudentFilterState(generalOptions)).toEqual(generalState);
+    expect(readStudentFilterState(userOptions)).toEqual(userState);
+    expect(storage.setItem).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not persist route-local batch state", () => {
+    const storage = createStorage();
+    installStorage(storage.storage);
+    const state = {
+      ...createStudentFilterState("recent"),
+      batchAddMode: true,
+      batchAddStudentUids: ["student-1"],
+    } as StudentFilterState & { batchAddMode: boolean; batchAddStudentUids: string[] };
+
+    writeStudentFilterState(generalOptions, state);
+
+    expect(JSON.parse(storage.setItem.mock.calls[0]?.[1] ?? "{}")).toEqual(createStudentFilterState("recent"));
+  });
+
+  it("falls back to defaults and keeps working when storage is malformed or unavailable", () => {
+    const storage = createStorage({ [generalOptions.storageKey]: "not-json" });
+    installStorage(storage.storage);
+
+    expect(readStudentFilterState(generalOptions)).toEqual(createStudentFilterState("recent"));
+
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("storage unavailable");
+      },
+    });
+
+    expect(readStudentFilterState(generalOptions)).toEqual(createStudentFilterState("recent"));
+    expect(() => writeStudentFilterState(generalOptions, createStudentFilterState("recent"))).not.toThrow();
+  });
+});

--- a/test/app/components/features/students/persistent-student-filter-state.test.ts
+++ b/test/app/components/features/students/persistent-student-filter-state.test.ts
@@ -1,58 +1,76 @@
-import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
 import { createStudentFilterState, type StudentFilterState } from "~/components/features/students/StudentFilter";
 import {
+  MAX_STUDENT_FILTER_COOKIE_SIZE,
   normalizeStudentFilterState,
-  type PersistentStudentFilterStateOptions,
-  readStudentFilterState,
-  writeStudentFilterState,
-} from "~/components/features/students/usePersistentStudentFilterState";
+  readStudentFilterStateFromCookie,
+  STUDENT_FILTER_COOKIE_MAX_AGE,
+  serializeStudentFilterStateCookie,
+  writeStudentFilterStateCookie,
+} from "~/components/features/students/student-filter-cookie";
+import type { PersistentStudentFilterStateOptions } from "~/components/features/students/usePersistentStudentFilterState";
 import { Attack, Defense } from "~/graphql/graphql";
 
 const generalOptions: PersistentStudentFilterStateOptions = {
-  storageKey: "mollulog::students::view-settings",
+  cookieName: "mollulog_students_filter",
+  cookiePath: "/students",
   defaultSort: "recent",
   allowedSorts: ["recent", "old", "name"],
 };
 
 const userOptions: PersistentStudentFilterStateOptions = {
-  storageKey: "mollulog::user-students::view-settings",
+  cookieName: "mollulog_user_students_filter",
+  cookiePath: "/",
   defaultSort: "recent",
   allowedSorts: ["recent", "old", "name", "tier"],
 };
 
-function createStorage(initial: Record<string, string> = {}) {
-  const values = new Map(Object.entries(initial));
-  const getItem = jest.fn((key: string) => values.get(key) ?? null);
-  const setItem = jest.fn((key: string, value: string) => {
-    values.set(key, value);
-  });
-
-  return {
-    storage: { getItem, setItem } as unknown as Storage,
-    getItem,
-    setItem,
-  };
+function cookieHeader(options: PersistentStudentFilterStateOptions, state: StudentFilterState): string {
+  const value = serializeStudentFilterStateCookie(options, state);
+  expect(value).not.toBeNull();
+  return `${options.cookieName}=${value}`;
 }
 
-let localStorageDescriptor: PropertyDescriptor | undefined;
+let documentDescriptor: PropertyDescriptor | undefined;
+let locationDescriptor: PropertyDescriptor | undefined;
 
 beforeEach(() => {
-  localStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
+  locationDescriptor = Object.getOwnPropertyDescriptor(globalThis, "location");
 });
 
 afterEach(() => {
-  if (localStorageDescriptor) {
-    Object.defineProperty(globalThis, "localStorage", localStorageDescriptor);
+  if (documentDescriptor) {
+    Object.defineProperty(globalThis, "document", documentDescriptor);
   } else {
-    Reflect.deleteProperty(globalThis, "localStorage");
+    Reflect.deleteProperty(globalThis, "document");
+  }
+
+  if (locationDescriptor) {
+    Object.defineProperty(globalThis, "location", locationDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "location");
   }
 });
 
-function installStorage(storage: Storage) {
-  Object.defineProperty(globalThis, "localStorage", {
+function installBrowser(protocol = "http:") {
+  let cookie = "";
+  Object.defineProperty(globalThis, "document", {
     configurable: true,
-    value: storage,
+    value: {
+      get cookie() {
+        return cookie;
+      },
+      set cookie(value: string) {
+        cookie = value;
+      },
+    },
   });
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: { protocol },
+  });
+  return () => cookie;
 }
 
 describe("persistent student filter state", () => {
@@ -79,22 +97,17 @@ describe("persistent student filter state", () => {
     });
   });
 
-  it("falls back to the screen default for an unsupported sort", () => {
+  it("falls back to the screen default for an unsupported sort and ignores search", () => {
     const normalized = normalizeStudentFilterState({ sort: "tier", search: "아루" }, generalOptions);
 
-    expect(normalized).toEqual({
-      ...createStudentFilterState("recent"),
-      search: "아루",
-    });
+    expect(normalized).toEqual(createStudentFilterState("recent"));
   });
 
   it("accepts tier sorting on the user student screen", () => {
     expect(normalizeStudentFilterState({ sort: "tier" }, userOptions)).toEqual(createStudentFilterState("tier"));
   });
 
-  it("keeps general and user student preferences under independent keys", () => {
-    const storage = createStorage();
-    installStorage(storage.storage);
+  it("keeps general and user student preferences in independent cookies", () => {
     const generalState: StudentFilterState = {
       ...createStudentFilterState("name"),
       attackTypes: [Attack.Explosive],
@@ -106,42 +119,73 @@ describe("persistent student filter state", () => {
       search: "시로코",
     };
 
-    writeStudentFilterState(generalOptions, generalState);
-    writeStudentFilterState(userOptions, userState);
-
-    expect(readStudentFilterState(generalOptions)).toEqual(generalState);
-    expect(readStudentFilterState(userOptions)).toEqual(userState);
-    expect(storage.setItem).toHaveBeenCalledTimes(2);
+    expect(readStudentFilterStateFromCookie(cookieHeader(generalOptions, generalState), generalOptions)).toEqual({
+      ...createStudentFilterState("name"),
+      attackTypes: [Attack.Explosive],
+    });
+    expect(readStudentFilterStateFromCookie(cookieHeader(userOptions, userState), userOptions)).toEqual({
+      ...createStudentFilterState("tier"),
+      defenseTypes: [Defense.Heavy],
+    });
+    expect(readStudentFilterStateFromCookie(cookieHeader(generalOptions, generalState), userOptions)).toEqual(
+      createStudentFilterState("recent"),
+    );
   });
 
-  it("does not persist route-local batch state", () => {
-    const storage = createStorage();
-    installStorage(storage.storage);
+  it("serializes only supported filters and sort, excluding search and route-local state", () => {
     const state = {
       ...createStudentFilterState("recent"),
+      search: "아루",
       batchAddMode: true,
       batchAddStudentUids: ["student-1"],
     } as StudentFilterState & { batchAddMode: boolean; batchAddStudentUids: string[] };
+    const serialized = serializeStudentFilterStateCookie(generalOptions, state);
 
-    writeStudentFilterState(generalOptions, state);
-
-    expect(JSON.parse(storage.setItem.mock.calls[0]?.[1] ?? "{}")).toEqual(createStudentFilterState("recent"));
+    expect(serialized).not.toBeNull();
+    expect(JSON.parse(decodeURIComponent(serialized as string))).toEqual(createStudentFilterState("recent"));
   });
 
-  it("falls back to defaults and keeps working when storage is malformed or unavailable", () => {
-    const storage = createStorage({ [generalOptions.storageKey]: "not-json" });
-    installStorage(storage.storage);
+  it("falls back to defaults for malformed, unknown, oversized, missing, or unavailable cookies", () => {
+    const defaults = createStudentFilterState("recent");
+    const unknownState = encodeURIComponent(JSON.stringify({ unknown: "value" }));
+    const oversizedValue = "x".repeat(MAX_STUDENT_FILTER_COOKIE_SIZE + 1);
 
-    expect(readStudentFilterState(generalOptions)).toEqual(createStudentFilterState("recent"));
+    expect(readStudentFilterStateFromCookie(`${generalOptions.cookieName}=not-json`, generalOptions)).toEqual(defaults);
+    expect(readStudentFilterStateFromCookie(`${generalOptions.cookieName}=%`, generalOptions)).toEqual(defaults);
+    expect(readStudentFilterStateFromCookie(`${generalOptions.cookieName}=${unknownState}`, generalOptions)).toEqual(
+      defaults,
+    );
+    expect(readStudentFilterStateFromCookie(`${generalOptions.cookieName}=${oversizedValue}`, generalOptions)).toEqual(
+      defaults,
+    );
+    expect(readStudentFilterStateFromCookie(null, generalOptions)).toEqual(defaults);
+    expect(() => writeStudentFilterStateCookie(generalOptions, defaults)).not.toThrow();
 
-    Object.defineProperty(globalThis, "localStorage", {
+    Object.defineProperty(globalThis, "document", {
       configurable: true,
       get() {
-        throw new Error("storage unavailable");
+        throw new Error("cookies unavailable");
       },
     });
+    expect(() => writeStudentFilterStateCookie(generalOptions, defaults)).not.toThrow();
+  });
 
-    expect(readStudentFilterState(generalOptions)).toEqual(createStudentFilterState("recent"));
-    expect(() => writeStudentFilterState(generalOptions, createStudentFilterState("recent"))).not.toThrow();
+  it("writes the cookie synchronously with local-development-safe attributes", () => {
+    const getCookie = installBrowser();
+    writeStudentFilterStateCookie(generalOptions, createStudentFilterState("old"));
+
+    expect(getCookie()).toContain(`${generalOptions.cookieName}=`);
+    expect(getCookie()).toContain("Path=/students");
+    expect(getCookie()).toContain(`Max-Age=${STUDENT_FILTER_COOKIE_MAX_AGE}`);
+    expect(getCookie()).toContain("SameSite=Lax");
+    expect(getCookie()).not.toContain("Secure");
+  });
+
+  it("adds Secure only when the browser is using HTTPS", () => {
+    const getCookie = installBrowser("https:");
+    writeStudentFilterStateCookie(userOptions, createStudentFilterState("tier"));
+
+    expect(getCookie()).toContain("Path=/");
+    expect(getCookie()).toContain("SameSite=Lax; Secure");
   });
 });

--- a/test/app/components/features/students/persistent-student-filter-state.test.ts
+++ b/test/app/components/features/students/persistent-student-filter-state.test.ts
@@ -13,7 +13,7 @@ import { Attack, Defense } from "~/graphql/graphql";
 
 const generalOptions: PersistentStudentFilterStateOptions = {
   cookieName: "mollulog_students_filter",
-  cookiePath: "/students",
+  cookiePath: "/",
   defaultSort: "recent",
   allowedSorts: ["recent", "old", "name"],
 };
@@ -175,7 +175,7 @@ describe("persistent student filter state", () => {
     writeStudentFilterStateCookie(generalOptions, createStudentFilterState("old"));
 
     expect(getCookie()).toContain(`${generalOptions.cookieName}=`);
-    expect(getCookie()).toContain("Path=/students");
+    expect(getCookie()).toContain("Path=/");
     expect(getCookie()).toContain(`Max-Age=${STUDENT_FILTER_COOKIE_MAX_AGE}`);
     expect(getCookie()).toContain("SameSite=Lax");
     expect(getCookie()).not.toContain("Secure");

--- a/test/app/components/features/students/student-filter.test.ts
+++ b/test/app/components/features/students/student-filter.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "@jest/globals";
 import {
+  clearStudentFilters,
   createStudentFilterState,
   getFilteredStudentUids,
+  hasActiveStudentFilters,
   type StudentFilterState,
 } from "~/components/features/students/StudentFilter";
 import { Attack, Defense } from "~/graphql/graphql";
@@ -26,6 +28,22 @@ function student(
 }
 
 describe("student filter", () => {
+  it("clears search and attribute filters while preserving the selected sort", () => {
+    const state: StudentFilterState = {
+      ...createStudentFilterState("tier"),
+      attackTypes: [Attack.Explosive],
+      defenseTypes: [Defense.Heavy],
+      search: "아루",
+    };
+
+    expect(hasActiveStudentFilters(state)).toBe(true);
+
+    const cleared = clearStudentFilters(state);
+
+    expect(cleared).toEqual({ ...createStudentFilterState("tier"), search: "" });
+    expect(hasActiveStudentFilters(cleared)).toBe(false);
+  });
+
   it("keeps the selected filter when only student tiers change", () => {
     const filterState: StudentFilterState = {
       ...createStudentFilterState("tier"),

--- a/test/app/components/features/students/student-filter.test.ts
+++ b/test/app/components/features/students/student-filter.test.ts
@@ -42,4 +42,17 @@ describe("student filter", () => {
 
     expect(getFilteredStudentUids(updatedStudents, filterState)).toEqual(["explosive-student"]);
   });
+
+  it("applies a restored search value to the filtered student list", () => {
+    const filterState: StudentFilterState = {
+      ...createStudentFilterState("recent"),
+      search: "아루",
+    };
+    const students = [
+      student({ uid: "aru", name: "아루", attackType: Attack.Explosive, order: 2 }),
+      student({ uid: "shiroko", name: "시로코", attackType: Attack.Explosive, order: 1 }),
+    ];
+
+    expect(getFilteredStudentUids(students, filterState)).toEqual(["aru"]);
+  });
 });

--- a/test/app/components/features/students/student-filter.test.ts
+++ b/test/app/components/features/students/student-filter.test.ts
@@ -43,7 +43,7 @@ describe("student filter", () => {
     expect(getFilteredStudentUids(updatedStudents, filterState)).toEqual(["explosive-student"]);
   });
 
-  it("applies a restored search value to the filtered student list", () => {
+  it("filters the student list by search value", () => {
     const filterState: StudentFilterState = {
       ...createStudentFilterState("recent"),
       search: "아루",

--- a/test/app/components/features/students/use-persistent-student-filter-state.test.ts
+++ b/test/app/components/features/students/use-persistent-student-filter-state.test.ts
@@ -33,7 +33,7 @@ import { Attack } from "~/graphql/graphql";
 
 const options: PersistentStudentFilterStateOptions = {
   cookieName: "mollulog_students_filter",
-  cookiePath: "/students",
+  cookiePath: "/",
   defaultSort: "recent",
   allowedSorts: ["recent", "old", "name"],
 };

--- a/test/app/components/features/students/use-persistent-student-filter-state.test.ts
+++ b/test/app/components/features/students/use-persistent-student-filter-state.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockSetState = jest.fn();
+const mockWriteStudentFilterStateCookie = jest.fn();
+
+jest.mock("react", () => {
+  const actual = jest.requireActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useCallback: (callback: unknown) => callback,
+    useMemo: (factory: () => unknown) => factory(),
+    useRef: (current: unknown) => ({ current }),
+    useState: (initial: unknown) => [
+      typeof initial === "function" ? (initial as () => unknown)() : initial,
+      mockSetState,
+    ],
+  };
+});
+
+jest.mock("~/components/features/students/student-filter-cookie", () => {
+  const actual = jest.requireActual<typeof import("~/components/features/students/student-filter-cookie")>(
+    "~/components/features/students/student-filter-cookie",
+  );
+  return { ...actual, writeStudentFilterStateCookie: mockWriteStudentFilterStateCookie };
+});
+
+import { createStudentFilterState } from "~/components/features/students/StudentFilter";
+import {
+  type PersistentStudentFilterStateOptions,
+  usePersistentStudentFilterState,
+} from "~/components/features/students/usePersistentStudentFilterState";
+import { Attack } from "~/graphql/graphql";
+
+const options: PersistentStudentFilterStateOptions = {
+  cookieName: "mollulog_students_filter",
+  cookiePath: "/students",
+  defaultSort: "recent",
+  allowedSorts: ["recent", "old", "name"],
+};
+
+beforeEach(() => {
+  mockSetState.mockClear();
+  mockWriteStudentFilterStateCookie.mockClear();
+});
+
+describe("usePersistentStudentFilterState persistence", () => {
+  it("skips writes for search-only updates and writes filter/sort changes immediately", () => {
+    const initialState = createStudentFilterState("recent");
+    const [, setState] = usePersistentStudentFilterState({ ...options, initialState });
+
+    setState({ ...initialState, search: "아루" });
+    expect(mockWriteStudentFilterStateCookie).not.toHaveBeenCalled();
+
+    setState({ ...initialState, attackTypes: [Attack.Explosive] });
+    expect(mockWriteStudentFilterStateCookie).toHaveBeenCalledTimes(1);
+    expect(mockWriteStudentFilterStateCookie.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSetState.mock.invocationCallOrder[1],
+    );
+
+    setState({ ...initialState, sort: "old" });
+    expect(mockWriteStudentFilterStateCookie).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/app/routes/students.test.ts
+++ b/test/app/routes/students.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { createStudentFilterState } from "~/components/features/students/StudentFilter";
+import { serializeStudentFilterStateCookie } from "~/components/features/students/student-filter-cookie";
+import { Attack, Defense } from "~/graphql/graphql";
+import { getAllStudents } from "~/models/student";
+import { loader, STUDENT_FILTER_COOKIE_NAME, STUDENT_FILTER_SORTS } from "~/routes/students";
+
+jest.mock("~/models/student", () => ({
+  getAllStudents: jest.fn(),
+}));
+
+const env = { HYPERDRIVE: { connectionString: "postgres://test" } } as unknown as Env;
+const mockedGetAllStudents = getAllStudents as jest.MockedFunction<typeof getAllStudents>;
+
+function createLoaderArgs(cookie?: string) {
+  return {
+    context: { cloudflare: { env } },
+    request: new Request("https://mollulog.test/students", {
+      headers: cookie ? { Cookie: cookie } : undefined,
+    }),
+    params: {},
+  } as never;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetAllStudents.mockResolvedValue([]);
+});
+
+describe("students loader", () => {
+  it("seeds the first render from the general student filter cookie", async () => {
+    const state = {
+      ...createStudentFilterState("name"),
+      defenseTypes: [Defense.Heavy],
+      search: "시로코",
+    };
+    const cookieValue = serializeStudentFilterStateCookie(
+      { defaultSort: "recent", allowedSorts: STUDENT_FILTER_SORTS },
+      state,
+    );
+    mockedGetAllStudents.mockResolvedValueOnce([
+      {
+        uid: "student-a",
+        name: "시로코",
+        attackType: Attack.Explosive,
+        defenseType: Defense.Heavy,
+        role: "striker",
+        position: "front",
+        tacticRole: "attacker",
+        order: 1,
+        initialTier: 3,
+      },
+    ] as never);
+
+    const result = await loader(createLoaderArgs(`${STUDENT_FILTER_COOKIE_NAME}=${cookieValue}`));
+
+    expect(result.filterState).toEqual({
+      ...createStudentFilterState("name"),
+      defenseTypes: [Defense.Heavy],
+    });
+    expect(result.students).toHaveLength(1);
+  });
+
+  it("uses the general allowlist when a user-only sort is present", async () => {
+    const state = createStudentFilterState("tier");
+    const cookieValue = serializeStudentFilterStateCookie(
+      { defaultSort: "recent", allowedSorts: ["recent", "old", "name"] },
+      state,
+    );
+
+    const result = await loader(createLoaderArgs(`${STUDENT_FILTER_COOKIE_NAME}=${cookieValue}`));
+
+    expect(result.filterState).toEqual(createStudentFilterState("recent"));
+  });
+});

--- a/test/app/routes/students.test.ts
+++ b/test/app/routes/students.test.ts
@@ -3,7 +3,12 @@ import { createStudentFilterState } from "~/components/features/students/Student
 import { serializeStudentFilterStateCookie } from "~/components/features/students/student-filter-cookie";
 import { Attack, Defense } from "~/graphql/graphql";
 import { getAllStudents } from "~/models/student";
-import { loader, STUDENT_FILTER_COOKIE_NAME, STUDENT_FILTER_SORTS } from "~/routes/students";
+import {
+  loader,
+  STUDENT_FILTER_COOKIE_NAME,
+  STUDENT_FILTER_COOKIE_PATH,
+  STUDENT_FILTER_SORTS,
+} from "~/routes/students";
 
 jest.mock("~/models/student", () => ({
   getAllStudents: jest.fn(),
@@ -28,6 +33,10 @@ beforeEach(() => {
 });
 
 describe("students loader", () => {
+  it("scopes the filter cookie to client-navigation data requests", () => {
+    expect(STUDENT_FILTER_COOKIE_PATH).toBe("/");
+  });
+
   it("seeds the first render from the general student filter cookie", async () => {
     const state = {
       ...createStudentFilterState("name"),

--- a/test/app/routes/username.students.test.ts
+++ b/test/app/routes/username.students.test.ts
@@ -39,11 +39,21 @@ jest.mock("~/models/student", () => ({
 }));
 
 jest.mock("~/components/features/students", () => ({
-  createStudentFilterState: jest.fn(),
   getFilteredStudentUids: jest.fn(),
   StudentCards: jest.fn(() => null),
   StudentFilter: jest.fn(() => null),
   TierSelector: jest.fn(() => null),
+  usePersistentStudentFilterState: jest.fn(() => [
+    {
+      attackTypes: [],
+      defenseTypes: [],
+      roles: [],
+      tacticRoles: [],
+      positions: [],
+      sort: "recent",
+    },
+    jest.fn(),
+  ]),
 }));
 
 jest.mock("~/components/primitives", () => ({

--- a/test/app/routes/username.students.test.ts
+++ b/test/app/routes/username.students.test.ts
@@ -1,15 +1,24 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { getActiveSensei } from "~/auth/authenticator.server";
+import { createStudentFilterState } from "~/components/features/students/StudentFilter";
+import { serializeStudentFilterStateCookie } from "~/components/features/students/student-filter-cookie";
+import { Attack, Defense } from "~/graphql/graphql";
 import { captureServerError, getLogger } from "~/lib/observability.server";
 import {
   addRecruitedStudents,
+  getRecruitedStudents,
   RecruitedStudentValidationError,
   removeRecruitedStudent,
   upsertRecruitedStudent,
 } from "~/models/recruited-student";
-import { getAllStudentsMap } from "~/models/student";
+import { getAllStudents, getAllStudentsMap } from "~/models/student";
 import { getRouteSensei } from "~/routes/$username._components/route-sensei.server";
-import { action } from "~/routes/$username.students";
+import {
+  action,
+  loader,
+  USER_STUDENT_FILTER_COOKIE_NAME,
+  USER_STUDENT_FILTER_SORTS,
+} from "~/routes/$username.students";
 
 jest.mock("~/auth/authenticator.server", () => ({
   getActiveSensei: jest.fn(),
@@ -67,6 +76,8 @@ const mockedGetActiveSensei = getActiveSensei as jest.MockedFunction<typeof getA
 const mockedCaptureServerError = captureServerError as jest.MockedFunction<typeof captureServerError>;
 const mockedGetLogger = getLogger as jest.MockedFunction<typeof getLogger>;
 const mockedGetRouteSensei = getRouteSensei as jest.MockedFunction<typeof getRouteSensei>;
+const mockedGetRecruitedStudents = getRecruitedStudents as jest.MockedFunction<typeof getRecruitedStudents>;
+const mockedGetAllStudents = getAllStudents as jest.MockedFunction<typeof getAllStudents>;
 const mockedGetAllStudentsMap = getAllStudentsMap as jest.MockedFunction<typeof getAllStudentsMap>;
 const mockedRemoveRecruitedStudent = removeRecruitedStudent as jest.MockedFunction<typeof removeRecruitedStudent>;
 const mockedUpsertRecruitedStudent = upsertRecruitedStudent as jest.MockedFunction<typeof upsertRecruitedStudent>;
@@ -82,6 +93,16 @@ function createActionArgs(formData: FormData, method = "POST") {
   return {
     context: { cloudflare: { env, ctx: {} as ExecutionContext } },
     request: new Request("https://mollulog.test/@sensei/students", { method, body: formData }),
+    params: { username: "@sensei" },
+  } as never;
+}
+
+function createLoaderArgs(cookie?: string) {
+  return {
+    context: { cloudflare: { env, ctx: {} as ExecutionContext } },
+    request: new Request("https://mollulog.test/@sensei/students", {
+      headers: cookie ? { Cookie: cookie } : undefined,
+    }),
     params: { username: "@sensei" },
   } as never;
 }
@@ -110,6 +131,8 @@ beforeEach(() => {
   mockedGetRouteSensei.mockResolvedValue({ id: 1, uid: "sensei-1", username: "sensei" } as Awaited<
     ReturnType<typeof getRouteSensei>
   >);
+  mockedGetRecruitedStudents.mockResolvedValue([]);
+  mockedGetAllStudents.mockResolvedValue([]);
   mockedGetAllStudentsMap.mockResolvedValue({
     "student-a": { uid: "student-a", released: true, initialTier: 3 },
     "student-b": { uid: "student-b", released: true, initialTier: 5 },
@@ -117,6 +140,41 @@ beforeEach(() => {
   mockedRemoveRecruitedStudent.mockResolvedValue(undefined);
   mockedUpsertRecruitedStudent.mockResolvedValue(undefined);
   mockedAddRecruitedStudents.mockResolvedValue(undefined);
+});
+
+describe("@username students loader", () => {
+  it("seeds the first render from the user student filter cookie", async () => {
+    const state = {
+      ...createStudentFilterState("tier"),
+      attackTypes: [Attack.Explosive],
+      search: "아루",
+    };
+    const cookieValue = serializeStudentFilterStateCookie(
+      { defaultSort: "recent", allowedSorts: USER_STUDENT_FILTER_SORTS },
+      state,
+    );
+    mockedGetRecruitedStudents.mockResolvedValueOnce([{ studentUid: "student-a", tier: 4 }] as never);
+    mockedGetAllStudents.mockResolvedValueOnce([
+      {
+        uid: "student-a",
+        name: "아루",
+        attackType: Attack.Explosive,
+        defenseType: Defense.Light,
+        role: "striker",
+        position: "front",
+        tacticRole: "attacker",
+        order: 1,
+        initialTier: 3,
+      },
+    ] as never);
+
+    const result = await loader(createLoaderArgs(`${USER_STUDENT_FILTER_COOKIE_NAME}=${cookieValue}`));
+
+    expect(result.filterState).toEqual({
+      ...createStudentFilterState("tier"),
+      attackTypes: [Attack.Explosive],
+    });
+  });
 });
 
 describe("@username students action", () => {


### PR DESCRIPTION
## Summary

Persist student-list filters and sort preferences across detail navigation without rendering the default list before browser state is restored. Both student-list routes now receive validated persisted state in their initial server render, while search remains transient.

## Changes

- store only filter and sort state in separate, size-bounded cookies for the public and user student lists
- validate cookie fields against the existing filter values and route-specific sort allowlists
- seed each route from loader data so SSR and hydration render the same filtered list on the first frame
- write cookie changes synchronously before navigation, while skipping search-only state updates
- remove local storage and search persistence; keep batch registration mode and selected student IDs route-local
- add focused codec, hook timing, search, and loader coverage

## Verification

- [x] I verified the related behavior myself.
- [ ] I ran `pnpm typecheck`, `pnpm exec biome check .`, and relevant tests when needed.
- [ ] (If AI tools were used) The generated content was reviewed by a person.

Completed checks:

- `mise exec -- pnpm exec jest --runInBand --runTestsByPath test/app/components/features/students/student-filter.test.ts test/app/components/features/students/persistent-student-filter-state.test.ts test/app/components/features/students/use-persistent-student-filter-state.test.ts test/app/routes/username.students.test.ts test/app/routes/students.test.ts` — 5 suites, 30 tests passed
- `mise exec -- pnpm run typecheck` — passed; existing `envFile` deprecation warnings remain
- targeted `mise exec -- pnpm exec biome check` on all changed source and test files — passed
- `mise exec -- pnpm run lint` — passed with existing warnings outside this change
- `git diff --check` — passed
- independent external review reproduced the focused tests and static checks and reported no actionable findings

The full generated-inclusive `mise exec -- pnpm exec biome check .` remains blocked by pre-existing diagnostics under `.react-router/types/**`; no generated files are part of this PR.

## Related issues

Related to MLLG-8, item 1 only. This PR intentionally does not close the full issue because item 2 is being handled separately.
