### PR TITLE
feat: add reply notification preferences

### DIFF
--- a/app/components/primitives/Dropdown.tsx
+++ b/app/components/primitives/Dropdown.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, ChevronDownIcon } from "@heroicons/react/16/solid";
-import { useEffect, useRef, useState } from "react";
+import { type KeyboardEvent, useEffect, useId, useRef, useState } from "react";
 import { cn } from "~/lib/utils";
 
 type DropdownOption<T extends string> = {
@@ -16,6 +16,12 @@ type DropdownProps<T extends string> = {
   size?: "md" | "sm" | "xs";
   className?: string;
   fullWidth?: boolean;
+  id?: string;
+  disabled?: boolean;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  "aria-describedby"?: string;
+  "aria-invalid"?: boolean | "false" | "true";
 };
 
 const optionColors = {
@@ -35,13 +41,108 @@ export default function Dropdown<T extends string>({
   size = "sm",
   className,
   fullWidth = false,
+  id,
+  disabled = false,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
+  "aria-describedby": ariaDescribedBy,
+  "aria-invalid": ariaInvalid,
 }: DropdownProps<T>) {
   const [isOpen, setIsOpen] = useState(false);
+  const [activeOptionIndex, setActiveOptionIndex] = useState(() => {
+    const selectedIndex = options.findIndex((option) => option.value === value);
+    return selectedIndex >= 0 ? selectedIndex : 0;
+  });
+  const generatedId = useId();
   const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const selectedOption = options.find((option) => option.value === value) ?? options[0];
+  const controlId = id ?? generatedId;
+  const menuId = `${controlId}-menu`;
+  const selectedOptionIndex = options.findIndex((option) => option.value === value);
+  const activeIndex = options.length > 0 ? Math.min(Math.max(activeOptionIndex, 0), options.length - 1) : -1;
+  const menuOpen = isOpen && !disabled;
+
+  const focusOption = (index: number) => {
+    if (options.length === 0) return;
+    const nextIndex = ((index % options.length) + options.length) % options.length;
+    setActiveOptionIndex(nextIndex);
+    optionRefs.current[nextIndex]?.focus();
+  };
+
+  const closeDropdown = () => {
+    setIsOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const selectOption = (nextValue: T) => {
+    onChange(nextValue);
+    closeDropdown();
+  };
+
+  const scheduleCloseForTab = () => {
+    window.setTimeout(() => setIsOpen(false), 0);
+  };
+
+  const openDropdown = (initialIndex = selectedOptionIndex >= 0 ? selectedOptionIndex : 0) => {
+    if (disabled) return;
+    setActiveOptionIndex(initialIndex);
+    setIsOpen(true);
+  };
+
+  const handleOptionKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number, optionValue: T) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      focusOption(index + 1);
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      focusOption(index - 1);
+      return;
+    }
+    if (event.key === "Home") {
+      event.preventDefault();
+      focusOption(0);
+      return;
+    }
+    if (event.key === "End") {
+      event.preventDefault();
+      focusOption(options.length - 1);
+      return;
+    }
+    if (event.key === "Tab") {
+      scheduleCloseForTab();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeDropdown();
+      return;
+    }
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      selectOption(optionValue);
+    }
+  };
 
   useEffect(() => {
-    if (!isOpen) {
+    if (disabled && isOpen) {
+      setIsOpen(false);
+    }
+  }, [disabled, isOpen]);
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+
+    optionRefs.current[activeIndex]?.focus();
+  }, [activeIndex, menuOpen]);
+
+  useEffect(() => {
+    if (!menuOpen) {
       return;
     }
 
@@ -53,15 +154,22 @@ export default function Dropdown<T extends string>({
 
     document.addEventListener("pointerdown", handlePointerDown);
     return () => document.removeEventListener("pointerdown", handlePointerDown);
-  }, [isOpen]);
+  }, [menuOpen]);
 
   return (
     <div ref={rootRef} className={cn("relative", fullWidth ? "w-full" : "w-fit", className)}>
-      {label && <p className="mb-1 text-xs font-medium text-muted-foreground">{label}</p>}
+      {label && (
+        <label className="mb-1 block text-xs font-medium text-muted-foreground" htmlFor={controlId}>
+          {label}
+        </label>
+      )}
       <button
+        ref={triggerRef}
+        id={controlId}
         type="button"
+        disabled={disabled}
         className={cn(
-          "inline-flex items-center justify-between gap-2 rounded-md border border-input bg-background font-medium text-foreground shadow-xs transition-colors hover:bg-muted",
+          "inline-flex items-center justify-between gap-2 rounded-md border border-input bg-background font-medium text-foreground shadow-xs outline-none transition-colors hover:bg-muted focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50",
           fullWidth && "w-full",
           size === "xs"
             ? "min-h-8 px-2.5 py-1 text-xs"
@@ -69,9 +177,40 @@ export default function Dropdown<T extends string>({
               ? "min-h-10 px-3 py-2 text-sm"
               : "min-h-9 px-3 py-1.5 text-sm",
         )}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={ariaInvalid}
         aria-haspopup="menu"
-        aria-expanded={isOpen}
-        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={menuOpen}
+        aria-controls={menuOpen ? menuId : undefined}
+        onClick={() => {
+          if (menuOpen) {
+            closeDropdown();
+          } else {
+            openDropdown();
+          }
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape" && menuOpen) {
+            event.preventDefault();
+            closeDropdown();
+            return;
+          }
+          if (event.key === "Tab" && menuOpen) {
+            scheduleCloseForTab();
+            return;
+          }
+          if (!menuOpen && event.key === "ArrowDown") {
+            event.preventDefault();
+            openDropdown();
+            return;
+          }
+          if (!menuOpen && event.key === "ArrowUp") {
+            event.preventDefault();
+            openDropdown(options.length - 1);
+          }
+        }}
       >
         <span className="inline-flex items-center gap-1.5">
           {selectedOption?.color && (
@@ -79,24 +218,39 @@ export default function Dropdown<T extends string>({
           )}
           {selectedOption?.label}
         </span>
-        <ChevronDownIcon className={cn("size-4 text-muted-foreground transition-transform", isOpen && "rotate-180")} />
+        <ChevronDownIcon
+          className={cn("size-4 text-muted-foreground transition-transform", menuOpen && "rotate-180")}
+        />
       </button>
-      {isOpen && (
-        <div className="absolute left-0 z-20 mt-1 max-h-72 min-w-full overflow-y-auto rounded-md bg-popover py-1 text-popover-foreground shadow-lg">
-          {options.map((option) => {
+      {menuOpen && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-labelledby={controlId}
+          aria-orientation="vertical"
+          className="absolute left-0 z-20 mt-1 max-h-72 min-w-full overflow-y-auto rounded-md bg-popover py-1 text-popover-foreground shadow-lg"
+        >
+          {options.map((option, index) => {
             const selected = option.value === value;
             return (
               <button
                 key={option.value}
                 type="button"
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
+                tabIndex={index === activeIndex ? 0 : -1}
                 className={cn(
-                  "flex w-full items-center justify-between gap-3 px-3 text-left whitespace-nowrap transition-colors",
+                  "flex w-full items-center justify-between gap-3 px-3 text-left whitespace-nowrap outline-none transition-colors focus-visible:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/30",
                   size === "xs" ? "py-1.5 text-xs" : "py-2 text-sm",
                   selected ? "bg-muted text-foreground" : "text-foreground hover:bg-muted/60",
                 )}
+                role="menuitemradio"
+                aria-checked={selected}
+                onFocus={() => setActiveOptionIndex(index)}
+                onKeyDown={(event) => handleOptionKeyDown(event, index, option.value)}
                 onClick={() => {
-                  onChange(option.value);
-                  setIsOpen(false);
+                  selectOption(option.value);
                 }}
               >
                 <span className="inline-flex items-center gap-1.5">

--- a/app/components/primitives/Toggle.tsx
+++ b/app/components/primitives/Toggle.tsx
@@ -7,6 +7,9 @@ type ToggleProps = {
   label?: string;
   initialState?: boolean;
   disabled?: boolean;
+  id?: string;
+  "aria-label"?: string;
+  "aria-invalid"?: boolean | "false" | "true";
   className?: string;
   trackClassName?: string;
   onChange?: (value: boolean) => void;
@@ -17,6 +20,9 @@ export default function Toggle({
   label,
   initialState,
   disabled,
+  id,
+  "aria-label": ariaLabel,
+  "aria-invalid": ariaInvalid,
   className,
   trackClassName,
   onChange,
@@ -31,11 +37,15 @@ export default function Toggle({
     <>
       <Field className={`${className ?? "my-4"} flex items-center`}>
         <Switch
+          id={id}
           disabled={disabled}
+          aria-label={ariaLabel}
+          aria-invalid={ariaInvalid}
           className={cn(
             `
-            h-5 w-10 p-0.5 group relative flex rounded-full transition-colors duration-200 ease-in-out
+            h-5 w-10 p-0.5 group relative flex rounded-full outline-none transition-colors duration-200 ease-in-out
             bg-input data-checked:bg-primary
+            focus-visible:ring-2 focus-visible:ring-ring/30
             ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}
           `,
             trackClassName,

--- a/app/db/postgres/schema.ts
+++ b/app/db/postgres/schema.ts
@@ -207,7 +207,9 @@ export type DiscordNotificationTrigger =
   | "event-end"
   | "reward-exchange-end"
   | "recruitment-start"
-  | "shop-reset";
+  | "shop-reset"
+  | "feedback-reply"
+  | "event-opinion-reply";
 export type DiscordNotificationJobTrigger = DiscordNotificationTrigger | "connection-verification";
 
 export type NotificationChannelType = "discord";

--- a/app/domain/discord-notifications.ts
+++ b/app/domain/discord-notifications.ts
@@ -1,6 +1,8 @@
 import type { DiscordNotificationTrigger } from "~/db/postgres/schema";
 
 export const DISCORD_NOTIFICATION_COMPLETION_MESSAGE = "몰루로그 Discord 알림 연결이 완료되었습니다.";
+export const DISCORD_NOTIFICATION_FEEDBACK_REPLY_MESSAGE = "작성한 제안/문의에 운영팀 답변이 등록되었습니다.";
+export const DISCORD_NOTIFICATION_EVENT_OPINION_REPLY_MESSAGE = "작성한 이벤트 의견에 새 답글이 등록되었습니다.";
 
 export const DISCORD_NOTIFICATION_DEFAULTS = {
   eventStartEnabled: false,
@@ -8,6 +10,8 @@ export const DISCORD_NOTIFICATION_DEFAULTS = {
   rewardExchangeEndEnabled: false,
   recruitmentStartEnabled: false,
   shopResetEnabled: false,
+  feedbackReplyEnabled: false,
+  eventOpinionReplyEnabled: false,
   leadHours: 24,
 };
 
@@ -42,6 +46,8 @@ export type DiscordNotificationSettingsInput = {
   rewardExchangeEndEnabled: boolean;
   recruitmentStartEnabled: boolean;
   shopResetEnabled: boolean;
+  feedbackReplyEnabled: boolean;
+  eventOpinionReplyEnabled: boolean;
   leadHours: number;
 };
 
@@ -140,6 +146,9 @@ export function formatDiscordNotificationMessage({
   contentName?: string | null;
   studentNames?: readonly (string | null | undefined)[];
 }): string {
+  if (trigger === "feedback-reply") return DISCORD_NOTIFICATION_FEEDBACK_REPLY_MESSAGE;
+  if (trigger === "event-opinion-reply") return DISCORD_NOTIFICATION_EVENT_OPINION_REPLY_MESSAGE;
+
   const at = formatKstNotificationTime(sourceAnchor);
   if (trigger === "recruitment-start") {
     const names = studentNames.map(requireName);
@@ -167,5 +176,7 @@ export function getEnabledTriggers(settings: DiscordNotificationSettingsInput): 
     settings.rewardExchangeEndEnabled ? "reward-exchange-end" : null,
     settings.recruitmentStartEnabled ? "recruitment-start" : null,
     settings.shopResetEnabled ? "shop-reset" : null,
+    settings.feedbackReplyEnabled ? "feedback-reply" : null,
+    settings.eventOpinionReplyEnabled ? "event-opinion-reply" : null,
   ].filter((trigger): trigger is DiscordNotificationTrigger => trigger !== null);
 }

--- a/app/models/discord-notifications.server.ts
+++ b/app/models/discord-notifications.server.ts
@@ -21,7 +21,9 @@ type DiscordNotificationSettingsKey =
   | "eventEndEnabled"
   | "rewardExchangeEndEnabled"
   | "recruitmentStartEnabled"
-  | "shopResetEnabled";
+  | "shopResetEnabled"
+  | "feedbackReplyEnabled"
+  | "eventOpinionReplyEnabled";
 
 const PREFERENCE_KEYS: ReadonlyArray<{
   type: DiscordNotificationTrigger;
@@ -32,6 +34,8 @@ const PREFERENCE_KEYS: ReadonlyArray<{
   { type: "reward-exchange-end", key: "rewardExchangeEndEnabled" },
   { type: "recruitment-start", key: "recruitmentStartEnabled" },
   { type: "shop-reset", key: "shopResetEnabled" },
+  { type: "feedback-reply", key: "feedbackReplyEnabled" },
+  { type: "event-opinion-reply", key: "eventOpinionReplyEnabled" },
 ];
 
 export type DiscordConnection = {
@@ -135,6 +139,8 @@ function mapPreferences(rows: readonly QueryRow[], now: Date): MappedPreferences
     rewardExchangeEndEnabled: byType.get("reward-exchange-end")?.enabled ?? false,
     recruitmentStartEnabled: byType.get("recruitment-start")?.enabled ?? false,
     shopResetEnabled: byType.get("shop-reset")?.enabled ?? false,
+    feedbackReplyEnabled: byType.get("feedback-reply")?.enabled ?? false,
+    eventOpinionReplyEnabled: byType.get("event-opinion-reply")?.enabled ?? false,
     leadHours: resolvedLeadHours,
     effectiveAt: (effectiveAt ?? now).toISOString(),
   };
@@ -153,6 +159,8 @@ export function parseDiscordNotificationSettingsForm(formData: FormData): Discor
     rewardExchangeEndEnabled: booleanValue("rewardExchangeEndEnabled"),
     recruitmentStartEnabled: booleanValue("recruitmentStartEnabled"),
     shopResetEnabled: booleanValue("shopResetEnabled"),
+    feedbackReplyEnabled: booleanValue("feedbackReplyEnabled"),
+    eventOpinionReplyEnabled: booleanValue("eventOpinionReplyEnabled"),
     leadHours: Number(leadHoursValue ?? Number.NaN),
   };
   return validateDiscordNotificationSettings(input);
@@ -244,10 +252,14 @@ export async function saveDiscordNotificationSettings(
       const effectiveTimes = PREFERENCE_KEYS.map(({ type, key }) => {
         const stored = existing.byType.get(type);
         const enabled = validated[key];
+        const preserveEffectiveAt =
+          stored &&
+          stored.enabled === enabled &&
+          (!leadHoursChanged || type === "feedback-reply" || type === "event-opinion-reply");
         return {
           type,
           enabled,
-          effectiveAt: stored && !leadHoursChanged && stored.enabled === enabled ? stored.effectiveAt : now,
+          effectiveAt: preserveEffectiveAt ? stored.effectiveAt : now,
         };
       });
 

--- a/app/routes/notifications._components/NotificationPreferencesCard.tsx
+++ b/app/routes/notifications._components/NotificationPreferencesCard.tsx
@@ -47,7 +47,7 @@ export default function NotificationPreferencesCard({
   };
 
   return (
-    <SectionCard title="받을 알림" description="알림은 수 분 정도 지연이 발생할 수 있어요">
+    <SectionCard title="받을 알림">
       {error ? (
         <p role="alert" className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
           {error}
@@ -73,8 +73,8 @@ export default function NotificationPreferencesCard({
               <h3 id="notification-game-content-heading" className="text-sm font-semibold text-foreground">
                 게임 컨텐츠 알림
               </h3>
-              <div className="space-y-1">
-                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+              <div>
+                <div className="p-2 flex items-center justify-between hover:bg-muted/70 rounded transition-colors">
                   <div className="min-w-0">
                     <p className="text-sm">이벤트 시작</p>
                     <p className="text-xs text-muted-foreground">새로운 이벤트 시작 알림</p>
@@ -88,7 +88,7 @@ export default function NotificationPreferencesCard({
                     onChange={markDirty}
                   />
                 </div>
-                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                <div className="p-2 flex items-center justify-between hover:bg-muted/70 rounded transition-colors">
                   <div className="min-w-0">
                     <p className="text-sm">이벤트 종료</p>
                     <p className="text-xs text-muted-foreground">이벤트 플레이 종료 시점 알림</p>
@@ -102,7 +102,7 @@ export default function NotificationPreferencesCard({
                     onChange={markDirty}
                   />
                 </div>
-                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                <div className="p-2 flex items-center justify-between hover:bg-muted/70 rounded transition-colors">
                   <div className="min-w-0">
                     <p className="text-sm">이벤트 보상 교환 종료</p>
                     <p className="text-xs text-muted-foreground">상점, 미션 등 이벤트 보상 획득 종료 시점 알림</p>
@@ -116,7 +116,7 @@ export default function NotificationPreferencesCard({
                     onChange={markDirty}
                   />
                 </div>
-                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                <div className="p-2 flex items-center justify-between hover:bg-muted/70 rounded transition-colors">
                   <div className="min-w-0">
                     <p className="text-sm">학생 모집 시작</p>
                     <p className="text-xs text-muted-foreground">관심 학생의 모집 시작 시점 알림</p>
@@ -130,7 +130,7 @@ export default function NotificationPreferencesCard({
                     onChange={markDirty}
                   />
                 </div>
-                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                <div className="p-2 flex items-center justify-between hover:bg-muted/70 rounded transition-colors">
                   <div className="min-w-0">
                     <p className="text-sm">상점 초기화 알림</p>
                     <p className="text-xs text-muted-foreground">매월 1일 상점 초기화 알림</p>
@@ -145,7 +145,11 @@ export default function NotificationPreferencesCard({
                   />
                 </div>
               </div>
-              <Field label="알림 시점" htmlFor="notification-lead-hours" containerClassName="space-y-3">
+              <Field
+                label="알림 시점"
+                htmlFor="notification-lead-hours"
+                description="알림은 기준 시점부터 수 분 정도 걸릴 수 있어요"
+              >
                 <Dropdown
                   id="notification-lead-hours"
                   value={leadHours}
@@ -161,15 +165,18 @@ export default function NotificationPreferencesCard({
               </Field>
             </section>
 
-            <section aria-labelledby="notification-mollulog-heading" className="space-y-4">
+            <section
+              className="space-y-4 border-t border-border pt-4"
+              aria-labelledby="notification-mollulog-heading"
+            >
               <h3 id="notification-mollulog-heading" className="text-sm font-semibold text-foreground">
                 몰루로그 알림
               </h3>
-              <div className="space-y-1">
-                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+              <div>
+                <div className="p-2 flex items-center justify-between hover:bg-muted/70 rounded transition-colors">
                   <div className="min-w-0">
                     <p className="text-sm">제안/문의 답글</p>
-                    <p className="text-xs text-muted-foreground">내 제안/문의에 등록된 운영팀 답변 알림</p>
+                    <p className="text-xs text-muted-foreground">제안/문의에 답변이 작성되면 알림</p>
                   </div>
                   <Toggle
                     name="feedbackReplyEnabled"
@@ -180,10 +187,10 @@ export default function NotificationPreferencesCard({
                     onChange={markDirty}
                   />
                 </div>
-                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                <div className="p-2 flex items-center justify-between hover:bg-muted/70 rounded transition-colors">
                   <div className="min-w-0">
                     <p className="text-sm">이벤트 의견 답글</p>
-                    <p className="text-xs text-muted-foreground">내 이벤트 의견에 달린 새 답글 알림</p>
+                    <p className="text-xs text-muted-foreground">내 이벤트 의견에 답글이 작성되면 알림</p>
                   </div>
                   <Toggle
                     name="eventOpinionReplyEnabled"

--- a/app/routes/notifications._components/NotificationPreferencesCard.tsx
+++ b/app/routes/notifications._components/NotificationPreferencesCard.tsx
@@ -165,10 +165,7 @@ export default function NotificationPreferencesCard({
               </Field>
             </section>
 
-            <section
-              className="space-y-4 border-t border-border pt-4"
-              aria-labelledby="notification-mollulog-heading"
-            >
+            <section className="space-y-4 border-t border-border pt-4" aria-labelledby="notification-mollulog-heading">
               <h3 id="notification-mollulog-heading" className="text-sm font-semibold text-foreground">
                 몰루로그 알림
               </h3>

--- a/app/routes/notifications._components/NotificationPreferencesCard.tsx
+++ b/app/routes/notifications._components/NotificationPreferencesCard.tsx
@@ -48,7 +48,16 @@ export default function NotificationPreferencesCard({
 
   return (
     <SectionCard title="받을 알림" description="알림은 수 분 정도 지연이 발생할 수 있어요">
-      {error ? <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</p> : null}
+      {error ? (
+        <p role="alert" className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+      {isSaved ? (
+        <p role="status" aria-live="polite" className="sr-only">
+          알림 설정이 저장됐어요.
+        </p>
+      ) : null}
       <Form method="post" onChange={markDirty}>
         <input type="hidden" name="intent" value="save" />
         <div className="relative">
@@ -60,81 +69,133 @@ export default function NotificationPreferencesCard({
             </div>
           ) : null}
           <fieldset disabled={!isAvailable} className={cn("min-w-0 space-y-6", !isAvailable && "opacity-40")}>
-            <div>
-              <div className="flex min-h-14 items-center justify-between gap-4 py-1">
-                <div className="min-w-0">
-                  <p className="text-sm">이벤트 시작</p>
-                  <p className="text-xs text-muted-foreground">새로운 이벤트 시작 알림</p>
+            <section aria-labelledby="notification-game-content-heading" className="space-y-4">
+              <h3 id="notification-game-content-heading" className="text-sm font-semibold text-foreground">
+                게임 컨텐츠 알림
+              </h3>
+              <div className="space-y-1">
+                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                  <div className="min-w-0">
+                    <p className="text-sm">이벤트 시작</p>
+                    <p className="text-xs text-muted-foreground">새로운 이벤트 시작 알림</p>
+                  </div>
+                  <Toggle
+                    name="eventStartEnabled"
+                    initialState={settings.eventStartEnabled}
+                    disabled={isSaving}
+                    aria-label="이벤트 시작"
+                    className="my-0 shrink-0"
+                    onChange={markDirty}
+                  />
                 </div>
-                <Toggle
-                  name="eventStartEnabled"
-                  initialState={settings.eventStartEnabled}
-                  className="my-0 shrink-0"
-                  onChange={markDirty}
-                />
-              </div>
-              <div className="flex min-h-14 items-center justify-between gap-4 py-1">
-                <div className="min-w-0">
-                  <p className="text-sm">이벤트 종료</p>
-                  <p className="text-xs text-muted-foreground">이벤트 플레이 종료 시점 알림</p>
+                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                  <div className="min-w-0">
+                    <p className="text-sm">이벤트 종료</p>
+                    <p className="text-xs text-muted-foreground">이벤트 플레이 종료 시점 알림</p>
+                  </div>
+                  <Toggle
+                    name="eventEndEnabled"
+                    initialState={settings.eventEndEnabled}
+                    disabled={isSaving}
+                    aria-label="이벤트 종료"
+                    className="my-0 shrink-0"
+                    onChange={markDirty}
+                  />
                 </div>
-                <Toggle
-                  name="eventEndEnabled"
-                  initialState={settings.eventEndEnabled}
-                  className="my-0 shrink-0"
-                  onChange={markDirty}
-                />
-              </div>
-              <div className="flex min-h-14 items-center justify-between gap-4 py-1">
-                <div className="min-w-0">
-                  <p className="text-sm">이벤트 보상 교환 종료</p>
-                  <p className="text-xs text-muted-foreground">상점, 미션 등 이벤트 보상 획득 종료 시점 알림</p>
+                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                  <div className="min-w-0">
+                    <p className="text-sm">이벤트 보상 교환 종료</p>
+                    <p className="text-xs text-muted-foreground">상점, 미션 등 이벤트 보상 획득 종료 시점 알림</p>
+                  </div>
+                  <Toggle
+                    name="rewardExchangeEndEnabled"
+                    initialState={settings.rewardExchangeEndEnabled}
+                    disabled={isSaving}
+                    aria-label="이벤트 보상 교환 종료"
+                    className="my-0 shrink-0"
+                    onChange={markDirty}
+                  />
                 </div>
-                <Toggle
-                  name="rewardExchangeEndEnabled"
-                  initialState={settings.rewardExchangeEndEnabled}
-                  className="my-0 shrink-0"
-                  onChange={markDirty}
-                />
-              </div>
-              <div className="flex min-h-14 items-center justify-between gap-4 py-1">
-                <div className="min-w-0">
-                  <p className="text-sm">학생 모집 시작</p>
-                  <p className="text-xs text-muted-foreground">관심 학생의 모집 시작 시점 알림</p>
+                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                  <div className="min-w-0">
+                    <p className="text-sm">학생 모집 시작</p>
+                    <p className="text-xs text-muted-foreground">관심 학생의 모집 시작 시점 알림</p>
+                  </div>
+                  <Toggle
+                    name="recruitmentStartEnabled"
+                    initialState={settings.recruitmentStartEnabled}
+                    disabled={isSaving}
+                    aria-label="학생 모집 시작"
+                    className="my-0 shrink-0"
+                    onChange={markDirty}
+                  />
                 </div>
-                <Toggle
-                  name="recruitmentStartEnabled"
-                  initialState={settings.recruitmentStartEnabled}
-                  className="my-0 shrink-0"
-                  onChange={markDirty}
-                />
-              </div>
-              <div className="flex min-h-14 items-center justify-between gap-4 py-1">
-                <div className="min-w-0">
-                  <p className="text-sm">상점 초기화 알림</p>
-                  <p className="text-xs text-muted-foreground">매월 1일 상점 초기화 알림</p>
+                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                  <div className="min-w-0">
+                    <p className="text-sm">상점 초기화 알림</p>
+                    <p className="text-xs text-muted-foreground">매월 1일 상점 초기화 알림</p>
+                  </div>
+                  <Toggle
+                    name="shopResetEnabled"
+                    initialState={settings.shopResetEnabled}
+                    disabled={isSaving}
+                    aria-label="상점 초기화 알림"
+                    className="my-0 shrink-0"
+                    onChange={markDirty}
+                  />
                 </div>
-                <Toggle
-                  name="shopResetEnabled"
-                  initialState={settings.shopResetEnabled}
-                  className="my-0 shrink-0"
-                  onChange={markDirty}
-                />
               </div>
-            </div>
+              <Field label="알림 시점" htmlFor="notification-lead-hours" containerClassName="space-y-3">
+                <Dropdown
+                  id="notification-lead-hours"
+                  value={leadHours}
+                  options={LEAD_HOUR_OPTIONS}
+                  size="md"
+                  fullWidth
+                  disabled={!isAvailable || isSaving}
+                  onChange={(value) => {
+                    setLeadHours(value);
+                    markDirty();
+                  }}
+                />
+              </Field>
+            </section>
 
-            <Field label="알림 시점" containerClassName="space-y-3">
-              <Dropdown
-                value={leadHours}
-                options={LEAD_HOUR_OPTIONS}
-                size="md"
-                fullWidth
-                onChange={(value) => {
-                  setLeadHours(value);
-                  markDirty();
-                }}
-              />
-            </Field>
+            <section aria-labelledby="notification-mollulog-heading" className="space-y-4">
+              <h3 id="notification-mollulog-heading" className="text-sm font-semibold text-foreground">
+                몰루로그 알림
+              </h3>
+              <div className="space-y-1">
+                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                  <div className="min-w-0">
+                    <p className="text-sm">제안/문의 답글</p>
+                    <p className="text-xs text-muted-foreground">내 제안/문의에 등록된 운영팀 답변 알림</p>
+                  </div>
+                  <Toggle
+                    name="feedbackReplyEnabled"
+                    initialState={settings.feedbackReplyEnabled}
+                    disabled={isSaving}
+                    aria-label="제안/문의 답글"
+                    className="my-0 shrink-0"
+                    onChange={markDirty}
+                  />
+                </div>
+                <div className="flex min-h-14 items-center justify-between gap-4 py-1">
+                  <div className="min-w-0">
+                    <p className="text-sm">이벤트 의견 답글</p>
+                    <p className="text-xs text-muted-foreground">내 이벤트 의견에 달린 새 답글 알림</p>
+                  </div>
+                  <Toggle
+                    name="eventOpinionReplyEnabled"
+                    initialState={settings.eventOpinionReplyEnabled}
+                    disabled={isSaving}
+                    aria-label="이벤트 의견 답글"
+                    className="my-0 shrink-0"
+                    onChange={markDirty}
+                  />
+                </div>
+              </div>
+            </section>
             <input type="hidden" name="leadHours" value={leadHours} />
 
             <div className="flex justify-end">

--- a/app/routes/notifications.tsx
+++ b/app/routes/notifications.tsx
@@ -32,6 +32,13 @@ type ActionData = {
   error?: string;
 };
 
+export function isNotificationSaveInFlight(navigation: {
+  state: "idle" | "loading" | "submitting";
+  formData?: FormData;
+}): boolean {
+  return navigation.state !== "idle" && navigation.formData?.get("intent") === "save";
+}
+
 export const action = async ({ request, context }: ActionFunctionArgs) => {
   const { env, ctx } = context.cloudflare;
   const sensei = await getActiveSensei(env, request, ctx);
@@ -65,8 +72,7 @@ export default function Notifications() {
   const actionData = useActionData<ActionData>();
   const navigation = useNavigation();
   const revalidator = useRevalidator();
-  const submittingIntent = navigation.formData?.get("intent");
-  const isSaving = navigation.state === "submitting" && submittingIntent === "save";
+  const isSaving = isNotificationSaveInFlight(navigation);
   const settingsActionData = actionData?.intent === "save" ? actionData : undefined;
   const globalError = actionData?.intent ? undefined : actionData?.error;
   const connectionStatus = state.connection?.status;
@@ -81,12 +87,11 @@ export default function Notifications() {
 
   return (
     <div className="max-w-3xl space-y-6">
-      <Title
-        text="알림 설정"
-        description="컨텐츠 일정을 잊지 않도록 알림으로 받아보세요"
-      />
+      <Title text="알림 설정" description="컨텐츠 일정을 잊지 않도록 알림으로 받아보세요" />
       {globalError ? (
-        <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">{globalError}</p>
+        <p role="alert" className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {globalError}
+        </p>
       ) : null}
       <NotificationChannelCard connection={state.connection} />
       <NotificationPreferencesCard

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -7,6 +7,7 @@ const config = {
   moduleNameMapper: {
     "^~/(.*)$": "<rootDir>/app/$1",
   },
+  testPathIgnorePatterns: ["<rootDir>/scripts/local-dev.test.mjs"],
 };
 
 export default config;

--- a/test/app/components/primitives/dropdown-accessibility.test.ts
+++ b/test/app/components/primitives/dropdown-accessibility.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "@jest/globals";
+
+const dropdownSource = readFileSync("app/components/primitives/Dropdown.tsx", "utf8");
+
+describe("Dropdown accessibility contract", () => {
+  it("keeps the menu-radio keyboard and focus recovery behavior", () => {
+    expect(dropdownSource).toContain('aria-haspopup="menu"');
+    expect(dropdownSource).toContain('role="menu"');
+    expect(dropdownSource).toContain('role="menuitemradio"');
+    expect(dropdownSource).toContain("aria-labelledby={controlId}");
+    expect(dropdownSource).toContain('event.key === "ArrowDown"');
+    expect(dropdownSource).toContain('event.key === "ArrowUp"');
+    expect(dropdownSource).toContain('event.key === "Home"');
+    expect(dropdownSource).toContain('event.key === "End"');
+    expect(dropdownSource).toContain('event.key === "Tab"');
+    expect(dropdownSource).toContain('event.key === "Escape"');
+    expect(dropdownSource).toContain("window.setTimeout(() => setIsOpen(false), 0)");
+    expect(dropdownSource).toContain("focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/30");
+    expect(dropdownSource).toContain("optionRefs.current[nextIndex]?.focus()");
+    expect(dropdownSource).toContain("triggerRef.current?.focus()");
+    expect(dropdownSource).toContain("tabIndex={index === activeIndex ? 0 : -1}");
+    expect(dropdownSource).toContain("const menuOpen = isOpen && !disabled");
+    expect(dropdownSource).toContain("if (disabled && isOpen)");
+  });
+});

--- a/test/app/domain/discord-notifications.test.ts
+++ b/test/app/domain/discord-notifications.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
 import {
   formatDiscordNotificationMessage,
+  getEnabledTriggers,
   getKstDateParts,
   isDiscordOAuthStateValid,
   isPastEffectiveAt,
@@ -8,6 +9,37 @@ import {
 } from "~/domain/discord-notifications";
 
 describe("Discord notification timing and copy", () => {
+  it("formats fixed messages for reactive reply triggers without source content", () => {
+    expect(
+      formatDiscordNotificationMessage({
+        trigger: "feedback-reply",
+        sourceAnchor: "2026-09-01T02:00:00.000Z",
+        contentName: "should not be included",
+      }),
+    ).toBe("작성한 제안/문의에 운영팀 답변이 등록되었습니다.");
+    expect(
+      formatDiscordNotificationMessage({
+        trigger: "event-opinion-reply",
+        sourceAnchor: "2026-09-01T02:00:00.000Z",
+      }),
+    ).toBe("작성한 이벤트 의견에 새 답글이 등록되었습니다.");
+  });
+
+  it("maps all seven settings to their notification triggers", () => {
+    expect(
+      getEnabledTriggers({
+        eventStartEnabled: true,
+        eventEndEnabled: false,
+        rewardExchangeEndEnabled: false,
+        recruitmentStartEnabled: false,
+        shopResetEnabled: false,
+        feedbackReplyEnabled: true,
+        eventOpinionReplyEnabled: true,
+        leadHours: 24,
+      }),
+    ).toEqual(["event-start", "feedback-reply", "event-opinion-reply"]);
+  });
+
   it("formats KST across a day boundary with the exact event copy", () => {
     const anchor = new Date("2026-08-31T15:00:00.000Z");
     expect(getKstDateParts(anchor)).toMatchObject({ year: 2026, month: 9, day: 1, hour: 0 });

--- a/test/app/models/discord-notifications.test.ts
+++ b/test/app/models/discord-notifications.test.ts
@@ -17,6 +17,15 @@ jest.mock("~/lib/postgres.server", () => ({
 
 const existingEffectiveAt = new Date("2026-08-01T00:00:00.000Z");
 const laterEffectiveAt = new Date("2026-09-02T00:00:00.000Z");
+const PREFERENCE_KEYS_FOR_TEST = [
+  "event-start",
+  "event-end",
+  "reward-exchange-end",
+  "recruitment-start",
+  "shop-reset",
+  "feedback-reply",
+  "event-opinion-reply",
+] as const;
 
 function preferenceRows(leadHours = 24, effectiveAt = existingEffectiveAt) {
   return [
@@ -25,17 +34,21 @@ function preferenceRows(leadHours = 24, effectiveAt = existingEffectiveAt) {
     { notification_type: "reward-exchange-end", enabled: false, lead_hours: leadHours, effective_at: effectiveAt },
     { notification_type: "recruitment-start", enabled: false, lead_hours: leadHours, effective_at: effectiveAt },
     { notification_type: "shop-reset", enabled: false, lead_hours: leadHours, effective_at: effectiveAt },
+    { notification_type: "feedback-reply", enabled: false, lead_hours: leadHours, effective_at: effectiveAt },
+    { notification_type: "event-opinion-reply", enabled: false, lead_hours: leadHours, effective_at: effectiveAt },
   ];
 }
 
 describe("Discord notification settings boundary", () => {
-  it("validates explicit settings and all five independent trigger values", () => {
+  it("validates explicit settings and all seven independent trigger values", () => {
     const form = new FormData();
     form.set("eventStartEnabled", "true");
     form.set("eventEndEnabled", "false");
     form.set("rewardExchangeEndEnabled", "true");
     form.set("recruitmentStartEnabled", "false");
     form.set("shopResetEnabled", "true");
+    form.set("feedbackReplyEnabled", "false");
+    form.set("eventOpinionReplyEnabled", "true");
     form.set("leadHours", "23");
     expect(parseDiscordNotificationSettingsForm(form)).toEqual({
       eventStartEnabled: true,
@@ -43,6 +56,8 @@ describe("Discord notification settings boundary", () => {
       rewardExchangeEndEnabled: true,
       recruitmentStartEnabled: false,
       shopResetEnabled: true,
+      feedbackReplyEnabled: false,
+      eventOpinionReplyEnabled: true,
       leadHours: 23,
     });
   });
@@ -84,7 +99,7 @@ describe("Discord notification settings boundary", () => {
     expect(statements.some((statement) => statement.startsWith("delete from notification_preferences"))).toBe(false);
   });
 
-  it("writes the shared lead time to all five preference rows transactionally", async () => {
+  it("writes the shared lead time to all seven preference rows transactionally", async () => {
     const statements: string[] = [];
     const insertValues: unknown[][] = [];
     const client = {
@@ -95,7 +110,7 @@ describe("Discord notification settings boundary", () => {
           return { rows: [{ status: "active" }], rowCount: 1 };
         }
         if (normalized.startsWith("select notification_type")) {
-          return { rows: preferenceRows(), rowCount: 5 };
+          return { rows: preferenceRows(), rowCount: 7 };
         }
         if (normalized.startsWith("insert into notification_preferences")) {
           insertValues.push([...values]);
@@ -114,6 +129,8 @@ describe("Discord notification settings boundary", () => {
         rewardExchangeEndEnabled: false,
         recruitmentStartEnabled: false,
         shopResetEnabled: false,
+        feedbackReplyEnabled: true,
+        eventOpinionReplyEnabled: false,
         leadHours: 12,
       },
       { now: () => laterEffectiveAt },
@@ -131,8 +148,65 @@ describe("Discord notification settings boundary", () => {
         "reward-exchange-end",
         "recruitment-start",
         "shop-reset",
+        "feedback-reply",
+        "event-opinion-reply",
         12,
       ]),
+    );
+  });
+
+  it("preserves reactive effective times on a lead-hours-only save while resetting schedule times", async () => {
+    const insertValues: unknown[][] = [];
+    const storedPreferences = preferenceRows().map((row) =>
+      row.notification_type === "feedback-reply" || row.notification_type === "event-opinion-reply"
+        ? { ...row, enabled: true }
+        : row,
+    );
+    const client = {
+      async query(text: string, values: readonly unknown[] = []) {
+        const normalized = text.replace(/\s+/g, " ").trim();
+        if (normalized.startsWith("select status from notification_channels")) {
+          return { rows: [{ status: "active" }], rowCount: 1 };
+        }
+        if (normalized.startsWith("select notification_type")) {
+          return { rows: storedPreferences, rowCount: storedPreferences.length };
+        }
+        if (normalized.startsWith("insert into notification_preferences")) {
+          insertValues.push([...values]);
+        }
+        return { rows: [], rowCount: 1 };
+      },
+    };
+    const env = { __pgClient: client } as unknown as Env;
+
+    await saveDiscordNotificationSettings(
+      env,
+      7,
+      {
+        eventStartEnabled: true,
+        eventEndEnabled: false,
+        rewardExchangeEndEnabled: false,
+        recruitmentStartEnabled: false,
+        shopResetEnabled: false,
+        feedbackReplyEnabled: true,
+        eventOpinionReplyEnabled: true,
+        leadHours: 12,
+      },
+      { now: () => laterEffectiveAt },
+    );
+
+    const values = insertValues[0];
+    expect(insertValues).toHaveLength(1);
+    expect(PREFERENCE_KEYS_FOR_TEST.map((type, index) => [type, values[4 + index * 5], values[3 + index * 5]])).toEqual(
+      [
+        ["event-start", laterEffectiveAt, 12],
+        ["event-end", laterEffectiveAt, 12],
+        ["reward-exchange-end", laterEffectiveAt, 12],
+        ["recruitment-start", laterEffectiveAt, 12],
+        ["shop-reset", laterEffectiveAt, 12],
+        ["feedback-reply", existingEffectiveAt, 12],
+        ["event-opinion-reply", existingEffectiveAt, 12],
+      ],
     );
   });
 
@@ -158,6 +232,8 @@ describe("Discord notification settings boundary", () => {
         rewardExchangeEndEnabled: false,
         recruitmentStartEnabled: false,
         shopResetEnabled: false,
+        feedbackReplyEnabled: false,
+        eventOpinionReplyEnabled: false,
         leadHours: 24,
       }),
     ).rejects.toThrow(DiscordNotificationSettingsInconsistentError);
@@ -191,6 +267,8 @@ describe("Discord notification settings boundary", () => {
         rewardExchangeEndEnabled: false,
         recruitmentStartEnabled: false,
         shopResetEnabled: true,
+        feedbackReplyEnabled: false,
+        eventOpinionReplyEnabled: false,
         leadHours: 24,
       },
       { now: () => laterEffectiveAt },
@@ -321,7 +399,7 @@ describe("Discord notification settings boundary", () => {
           return { rows: [{ status: "active", recipient_key: "1234567890" }], rowCount: 1 };
         }
         if (normalized.startsWith("select notification_type")) {
-          return { rows: preferenceRows(), rowCount: 5 };
+          return { rows: preferenceRows(), rowCount: 7 };
         }
         return { rows: [], rowCount: 0 };
       },

--- a/test/app/routes/discord-auth-boundaries.test.ts
+++ b/test/app/routes/discord-auth-boundaries.test.ts
@@ -68,6 +68,18 @@ describe("Discord page responsibility", () => {
     expect(notificationPreferencesSource).toContain("하나 이상의 알림 수단을 등록해주세요");
     expect(notificationPreferencesSource).toContain("disabled={!isAvailable}");
     expect(notificationPreferencesSource).toContain('!isAvailable && "opacity-40"');
+    expect(notificationPreferencesSource).toContain("게임 컨텐츠 알림");
+    expect(notificationPreferencesSource).toContain("몰루로그 알림");
+    expect(notificationPreferencesSource).toContain('id="notification-game-content-heading"');
+    expect(notificationPreferencesSource).toContain('aria-labelledby="notification-game-content-heading"');
+    expect(notificationPreferencesSource).toContain('id="notification-mollulog-heading"');
+    expect(notificationPreferencesSource).toContain('aria-labelledby="notification-mollulog-heading"');
+    expect(notificationPreferencesSource).toContain('label="알림 시점" htmlFor="notification-lead-hours"');
+    expect(notificationPreferencesSource).not.toContain("게임 컨텐츠 알림에 공통으로 적용돼요.");
+    expect(notificationPreferencesSource).toContain("내 제안/문의에 등록된 운영팀 답변 알림");
+    expect(notificationPreferencesSource).toContain("내 이벤트 의견에 달린 새 답글 알림");
+    expect(notificationPreferencesSource).toContain('role="alert"');
+    expect(notificationPreferencesSource).toContain('aria-live="polite"');
     expect(notificationChannelSource).not.toContain("<Form");
     expect(notificationsSource).not.toContain("/notifications/discord");
   });

--- a/test/app/routes/discord-auth-boundaries.test.ts
+++ b/test/app/routes/discord-auth-boundaries.test.ts
@@ -68,18 +68,6 @@ describe("Discord page responsibility", () => {
     expect(notificationPreferencesSource).toContain("하나 이상의 알림 수단을 등록해주세요");
     expect(notificationPreferencesSource).toContain("disabled={!isAvailable}");
     expect(notificationPreferencesSource).toContain('!isAvailable && "opacity-40"');
-    expect(notificationPreferencesSource).toContain("게임 컨텐츠 알림");
-    expect(notificationPreferencesSource).toContain("몰루로그 알림");
-    expect(notificationPreferencesSource).toContain('id="notification-game-content-heading"');
-    expect(notificationPreferencesSource).toContain('aria-labelledby="notification-game-content-heading"');
-    expect(notificationPreferencesSource).toContain('id="notification-mollulog-heading"');
-    expect(notificationPreferencesSource).toContain('aria-labelledby="notification-mollulog-heading"');
-    expect(notificationPreferencesSource).toContain('label="알림 시점" htmlFor="notification-lead-hours"');
-    expect(notificationPreferencesSource).not.toContain("게임 컨텐츠 알림에 공통으로 적용돼요.");
-    expect(notificationPreferencesSource).toContain("내 제안/문의에 등록된 운영팀 답변 알림");
-    expect(notificationPreferencesSource).toContain("내 이벤트 의견에 달린 새 답글 알림");
-    expect(notificationPreferencesSource).toContain('role="alert"');
-    expect(notificationPreferencesSource).toContain('aria-live="polite"');
     expect(notificationChannelSource).not.toContain("<Form");
     expect(notificationsSource).not.toContain("/notifications/discord");
   });

--- a/test/app/routes/notification-preferences-accessibility.test.ts
+++ b/test/app/routes/notification-preferences-accessibility.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "@jest/globals";
+
+const preferencesSource = readFileSync("app/routes/notifications._components/NotificationPreferencesCard.tsx", "utf8");
+const toggleSource = readFileSync("app/components/primitives/Toggle.tsx", "utf8");
+
+describe("notification preference accessibility", () => {
+  it("gives every notification switch a direct accessible name", () => {
+    for (const label of [
+      "이벤트 시작",
+      "이벤트 종료",
+      "이벤트 보상 교환 종료",
+      "학생 모집 시작",
+      "상점 초기화 알림",
+      "제안/문의 답글",
+      "이벤트 의견 답글",
+    ]) {
+      expect(preferencesSource).toContain(`aria-label="${label}"`);
+    }
+
+    expect(preferencesSource).not.toContain("notification-event-start-label");
+    expect(preferencesSource).not.toContain("notification-event-start-description");
+    expect(preferencesSource).not.toContain("notification-feedback-reply-label");
+    expect(preferencesSource).not.toContain("notification-feedback-reply-description");
+    expect(toggleSource).not.toContain('"aria-labelledby"?: string');
+    expect(toggleSource).not.toContain('"aria-describedby"?: string');
+  });
+});

--- a/test/app/routes/notification-preferences-accessibility.test.ts
+++ b/test/app/routes/notification-preferences-accessibility.test.ts
@@ -25,4 +25,19 @@ describe("notification preference accessibility", () => {
     expect(toggleSource).not.toContain('"aria-labelledby"?: string');
     expect(toggleSource).not.toContain('"aria-describedby"?: string');
   });
+
+  it("keeps preference groups and feedback states semantically connected", () => {
+    expect(preferencesSource).toContain("게임 컨텐츠 알림");
+    expect(preferencesSource).toContain("몰루로그 알림");
+    expect(preferencesSource).toContain('id="notification-game-content-heading"');
+    expect(preferencesSource).toContain('aria-labelledby="notification-game-content-heading"');
+    expect(preferencesSource).toContain('id="notification-mollulog-heading"');
+    expect(preferencesSource).toContain('aria-labelledby="notification-mollulog-heading"');
+    expect(preferencesSource).toContain('label="알림 시점" htmlFor="notification-lead-hours"');
+    expect(preferencesSource).not.toContain("게임 컨텐츠 알림에 공통으로 적용돼요.");
+    expect(preferencesSource).toContain("내 제안/문의에 등록된 운영팀 답변 알림");
+    expect(preferencesSource).toContain("내 이벤트 의견에 달린 새 답글 알림");
+    expect(preferencesSource).toContain('role="alert"');
+    expect(preferencesSource).toContain('aria-live="polite"');
+  });
 });

--- a/test/app/routes/notification-preferences-accessibility.test.ts
+++ b/test/app/routes/notification-preferences-accessibility.test.ts
@@ -33,10 +33,10 @@ describe("notification preference accessibility", () => {
     expect(preferencesSource).toContain('aria-labelledby="notification-game-content-heading"');
     expect(preferencesSource).toContain('id="notification-mollulog-heading"');
     expect(preferencesSource).toContain('aria-labelledby="notification-mollulog-heading"');
-    expect(preferencesSource).toContain('label="알림 시점" htmlFor="notification-lead-hours"');
+    expect(preferencesSource).toMatch(/<Field\s+label="알림 시점"\s+htmlFor="notification-lead-hours"/);
     expect(preferencesSource).not.toContain("게임 컨텐츠 알림에 공통으로 적용돼요.");
-    expect(preferencesSource).toContain("내 제안/문의에 등록된 운영팀 답변 알림");
-    expect(preferencesSource).toContain("내 이벤트 의견에 달린 새 답글 알림");
+    expect(preferencesSource).toContain("제안/문의에 답변이 작성되면 알림");
+    expect(preferencesSource).toContain("내 이벤트 의견에 답글이 작성되면 알림");
     expect(preferencesSource).toContain('role="alert"');
     expect(preferencesSource).toContain('aria-live="polite"');
   });

--- a/test/app/routes/notifications-lifecycle.test.ts
+++ b/test/app/routes/notifications-lifecycle.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+jest.mock("~/auth/authenticator.server", () => ({ getActiveSensei: jest.fn() }));
+jest.mock("~/components/primitives", () => ({ Title: () => null }));
+jest.mock("~/models/discord-notifications.server", () => ({
+  DiscordNotificationValidationError: class DiscordNotificationValidationError extends Error {},
+  DiscordSettingsUnavailableError: class DiscordSettingsUnavailableError extends Error {},
+  getDiscordNotificationState: jest.fn(),
+  parseDiscordNotificationSettingsForm: jest.fn(),
+  saveDiscordNotificationSettings: jest.fn(),
+}));
+jest.mock("~/routes/notifications._components/NotificationChannelCard", () => () => null);
+jest.mock("~/routes/notifications._components/NotificationPreferencesCard", () => () => null);
+
+import { isNotificationSaveInFlight } from "~/routes/notifications";
+
+describe("notification save navigation lifecycle", () => {
+  it("keeps save controls busy through loading and releases them at idle", () => {
+    const saveFormData = new FormData();
+    saveFormData.set("intent", "save");
+
+    expect(isNotificationSaveInFlight({ state: "submitting", formData: saveFormData })).toBe(true);
+    expect(isNotificationSaveInFlight({ state: "loading", formData: saveFormData })).toBe(true);
+    expect(isNotificationSaveInFlight({ state: "idle", formData: saveFormData })).toBe(false);
+    expect(isNotificationSaveInFlight({ state: "loading" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Add user-configurable Discord notifications for replies to feedback tickets and event opinions.

## Changes

- Extend notification preference parsing, persistence, and state handling for feedback and event-opinion replies.
- Refine `/notifications` into grouped, accessible preferences with reactive pending/saved/error states.
- Improve shared Dropdown and Toggle accessibility behavior.
- Add lifecycle, domain/model, and accessibility coverage; keep the Node-native local-dev test out of Jest discovery.
- UI: `/notifications` now separates game-content alerts from MolluLog reply alerts and provides clear save feedback.

## Verification

- [x] I verified the related behavior myself.
- [x] I ran the relevant typecheck, lint, formatting, and test checks when needed.
- [ ] (If AI tools were used) The generated content was reviewed by a person.

Verified:

- `mise exec -- pnpm run typecheck`
- `mise exec -- pnpm run lint` (passes; existing warnings remain)
- `mise exec -- pnpm exec jest --runInBand` (230 suites, 1509 tests passed)
- `mise exec -- pnpm run test:local-dev` (5 passed, 1 skipped)
- Changed-file Biome check and `git diff --check`

Note: repository-wide `pnpm exec biome check .` reports formatting diagnostics in generated `.react-router/types` files only; no source fixes were applied for those generated files.

## Related issues

Resolves MLLG-11