### PR TITLE
[MLLG-16] Show recruitment period mismatch notices

### DIFF
--- a/app/components/features/contents/ContentTimeline.tsx
+++ b/app/components/features/contents/ContentTimeline.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useDisplayTimeZone } from "~/contexts/TimeZoneProvider";
+import type { RecruitmentPeriod } from "~/domain/recruitment-period-notice";
 import { formatInstant, formatInstantDateKey, nowUtcIso, parseUtcTimestamp, type UtcIsoString } from "~/lib/date-time";
 import type { EventType, RaidType } from "~/models/content.d";
 import { COMMENT_ENABLED_WITHOUT_RECRUITMENT_CONTENT_TYPES } from "~/models/content-rules";
@@ -37,6 +38,7 @@ export type ContentTimelineProps = {
     runType: "first" | "rerun" | "permanent";
     uid: string;
     recruitmentGroupUid?: string | null;
+    recruitmentPeriod?: RecruitmentPeriod | null;
     link: string;
     contentType: EventType | RaidType;
     confirmed?: boolean;
@@ -61,6 +63,7 @@ export type ContentTimelineProps = {
   signedIn: boolean;
   recruitmentStudentMobileGrid?: 5 | 6;
   showFeatureBanners?: boolean;
+  showRecruitmentPeriodNotice?: boolean;
   revealedSpoilerContentUids?: string[];
   onRevealSpoiler?: (contentUid: string) => void;
   onHideSpoiler?: (contentUid: string) => void;
@@ -108,6 +111,7 @@ export default function ContentTimeline({
   isSubmittingComment,
   signedIn,
   showFeatureBanners = false,
+  showRecruitmentPeriodNotice = true,
   recruitmentStudentMobileGrid,
 }: ContentTimelineProps) {
   const displayTimeZone = useDisplayTimeZone();
@@ -195,6 +199,7 @@ export default function ContentTimeline({
                       key={content.uid}
                       confirmed={content.confirmed}
                       {...content}
+                      recruitmentPeriod={showRecruitmentPeriodNotice ? content.recruitmentPeriod : null}
                       spoilerVisible={spoilerVisible}
                       onRevealSpoiler={content.isSpoiler ? () => onRevealSpoiler?.(content.uid) : undefined}
                       onHideSpoiler={content.isSpoiler ? () => onHideSpoiler?.(content.uid) : undefined}

--- a/app/components/features/contents/ContentTimelineCompact.tsx
+++ b/app/components/features/contents/ContentTimelineCompact.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleIcon, HeartIcon as EmptyHeartIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
+import { CheckCircleIcon, ClockIcon, HeartIcon as EmptyHeartIcon } from "@heroicons/react/24/outline";
 import { HeartIcon as FilledHeartIcon } from "@heroicons/react/24/solid";
 import { useMemo } from "react";
 import { useNavigate } from "react-router";
@@ -223,7 +223,7 @@ function CompactContentItem({
       )}
       {spoilerVisible && recruitmentPeriodNotice && (
         <p className="mt-1 flex min-w-0 items-start gap-1 text-xs text-amber-600 dark:text-amber-400">
-          <ExclamationTriangleIcon aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
+          <ClockIcon aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
           <span className="min-w-0">{recruitmentPeriodNotice}</span>
         </p>
       )}

--- a/app/components/features/contents/ContentTimelineCompact.tsx
+++ b/app/components/features/contents/ContentTimelineCompact.tsx
@@ -1,9 +1,10 @@
-import { CheckCircleIcon, HeartIcon as EmptyHeartIcon } from "@heroicons/react/24/outline";
+import { CheckCircleIcon, HeartIcon as EmptyHeartIcon, ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { HeartIcon as FilledHeartIcon } from "@heroicons/react/24/solid";
 import { useMemo } from "react";
 import { useNavigate } from "react-router";
 import { StudentCard } from "~/components/features/students";
 import { useDisplayTimeZone } from "~/contexts/TimeZoneProvider";
+import { getRecruitmentPeriodNotice } from "~/domain/recruitment-period-notice";
 import { formatInstant, formatInstantDateKey, nowUtcIso, parseUtcTimestamp } from "~/lib/date-time";
 import { contentTypeLocale } from "~/locales/ko";
 import type { RecruitmentCompletionMeta } from "~/models/recruitment-result";
@@ -165,6 +166,17 @@ function CompactContentItem({
   });
   const title = hiddenSpoiler ? "???" : content.name.split("\n").join(" ");
   const label = getContentTypeLabel(content);
+  const recruitmentPeriodNotice = getRecruitmentPeriodNotice(
+    {
+      recruitmentGroupUid: content.recruitmentGroupUid,
+      contentType: content.contentType,
+      startAt: content.since,
+      endAt: content.until,
+      endless: content.endless,
+    },
+    content.recruitmentPeriod,
+    nowUtcIso(),
+  );
   const lineContent = (
     <span className="flex min-w-0 items-baseline gap-2">
       <span className="shrink-0 text-xs text-neutral-500 dark:text-neutral-400">{label}</span>
@@ -208,6 +220,12 @@ function CompactContentItem({
           onFavorite={onFavorite}
           onRecruitmentComplete={onRecruitmentComplete}
         />
+      )}
+      {spoilerVisible && recruitmentPeriodNotice && (
+        <p className="mt-1 flex min-w-0 items-start gap-1 text-xs text-amber-600 dark:text-amber-400">
+          <ExclamationTriangleIcon aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
+          <span className="min-w-0">{recruitmentPeriodNotice}</span>
+        </p>
       )}
     </div>
   );

--- a/app/components/features/contents/ContentTimelineItem.tsx
+++ b/app/components/features/contents/ContentTimelineItem.tsx
@@ -17,7 +17,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { HeartIcon as FilledHeartIcon } from "@heroicons/react/24/solid";
 import { type ReactNode, useMemo, useState } from "react";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import { RaidCard } from "~/components/features/raids";
 import { StudentCards } from "~/components/features/students";
 import { BottomSheet, Button } from "~/components/primitives";
@@ -196,6 +196,7 @@ export function ContentTimelineItem({
   signedIn,
   recruitmentStudentMobileGrid,
 }: ContentTimelineItemProps) {
+  const navigate = useNavigate();
   const displayTimeZone = useDisplayTimeZone();
   const { setActivePopupId } = useStudentCardPopup();
   const showComments =
@@ -302,7 +303,16 @@ export function ContentTimelineItem({
           studentMobileGrid={recruitmentStudentMobileGrid}
         />
       )}
-      {recruitmentPeriodNotice && <TimelineItemBanner message={recruitmentPeriodNotice} color="amber" />}
+      {recruitmentPeriodNotice && (
+        <TimelineItemBanner
+          message={recruitmentPeriodNotice}
+          color="amber"
+          icon="clock"
+          onLinkClick={() => navigate(link)}
+          linkText="자세히"
+          actionVariant="button"
+        />
+      )}
       {completedStudentUids.length > 0 && recruitmentResultEditLink && (
         <div className="my-2">
           <Button

--- a/app/components/features/contents/ContentTimelineItem.tsx
+++ b/app/components/features/contents/ContentTimelineItem.tsx
@@ -23,6 +23,7 @@ import { StudentCards } from "~/components/features/students";
 import { BottomSheet, Button } from "~/components/primitives";
 import { useStudentCardPopup } from "~/contexts/StudentCardPopupProvider";
 import { useDisplayTimeZone } from "~/contexts/TimeZoneProvider";
+import { getRecruitmentPeriodNotice, type RecruitmentPeriod } from "~/domain/recruitment-period-notice";
 import { canCompleteRecruitmentStudent } from "~/domain/recruitment-result";
 import type { Attack, Defense, RecruitmentTypeEnum, Terrain } from "~/graphql/graphql";
 import {
@@ -61,6 +62,8 @@ export type ContentTimelineItemProps = {
   isSpoiler?: boolean;
   spoilerVisible?: boolean;
   tags: string[];
+  recruitmentGroupUid?: string | null;
+  recruitmentPeriod?: RecruitmentPeriod | null;
 
   allComments?: {
     uid: string;
@@ -163,6 +166,8 @@ export function ContentTimelineItem({
   isSpoiler = false,
   spoilerVisible = true,
   tags,
+  recruitmentGroupUid,
+  recruitmentPeriod,
   raidInfo,
   recruitments,
   allComments,
@@ -199,6 +204,13 @@ export function ContentTimelineItem({
 
   let daysLabel = null;
   const now = nowUtcIso();
+  const recruitmentPeriodNotice = since
+    ? getRecruitmentPeriodNotice(
+        { recruitmentGroupUid, contentType, startAt: since, endAt: until, endless },
+        recruitmentPeriod,
+        now,
+      )
+    : null;
 
   let finishSoon = false;
   if (since && until && isInstantBefore(since, now)) {
@@ -290,6 +302,7 @@ export function ContentTimelineItem({
           studentMobileGrid={recruitmentStudentMobileGrid}
         />
       )}
+      {recruitmentPeriodNotice && <TimelineItemBanner message={recruitmentPeriodNotice} color="amber" />}
       {completedStudentUids.length > 0 && recruitmentResultEditLink && (
         <div className="my-2">
           <Button

--- a/app/components/features/contents/TimelineItemBanner.tsx
+++ b/app/components/features/contents/TimelineItemBanner.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router";
-import { ExclamationTriangleIcon, SparklesIcon, Squares2X2Icon, XMarkIcon } from "@heroicons/react/16/solid";
+import { ClockIcon, ExclamationTriangleIcon, SparklesIcon, Squares2X2Icon, XMarkIcon } from "@heroicons/react/16/solid";
 import type { ReactNode } from "react";
 
 type TimelineItemBannerProps = {
@@ -8,9 +8,10 @@ type TimelineItemBannerProps = {
   link?: string;
   linkText?: string;
   onLinkClick?: () => void;
+  actionVariant?: "link" | "button";
   onDismiss?: () => void;
   dismissLabel?: string;
-  icon?: "exclamation" | "info" | "menu";
+  icon?: "clock" | "exclamation" | "info" | "menu";
   color?: "amber" | "green" | "neutral";
 };
 
@@ -53,17 +54,26 @@ export function TimelineItemBanner({
   link,
   linkText = "자세히 보기",
   onLinkClick,
+  actionVariant = "link",
   onDismiss,
   dismissLabel = "배너 닫기",
   icon = "exclamation",
   color = "amber",
 }: TimelineItemBannerProps) {
-  const IconComponent = icon === "info" ? SparklesIcon : icon === "menu" ? Squares2X2Icon : ExclamationTriangleIcon;
+  const IconComponent =
+    icon === "clock"
+      ? ClockIcon
+      : icon === "info"
+        ? SparklesIcon
+        : icon === "menu"
+          ? Squares2X2Icon
+          : ExclamationTriangleIcon;
   const classes = colorClasses[color];
   const structured = Boolean(title || onDismiss);
-  const linkClassName = structured
-    ? `inline-flex items-center rounded-md px-2 py-1 text-xs font-semibold leading-4 transition ${classes.action}`
-    : `inline-flex flex-shrink-0 items-center underline cursor-pointer ${classes.link}`;
+  const linkClassName =
+    structured || actionVariant === "button"
+      ? `inline-flex cursor-pointer items-center rounded-md px-2 py-1 text-xs font-semibold leading-4 transition ${classes.action}`
+      : `inline-flex flex-shrink-0 items-center underline cursor-pointer ${classes.link}`;
   const renderAction = (className = "") => {
     const actionClassName = className ? `${linkClassName} ${className}` : linkClassName;
     if (link) {

--- a/app/domain/recruitment-period-notice.ts
+++ b/app/domain/recruitment-period-notice.ts
@@ -1,0 +1,46 @@
+import { getInstantTime, type UtcIsoString } from "~/lib/date-time";
+
+export type RecruitmentPeriod = {
+  startAt: UtcIsoString;
+  endAt: UtcIsoString | null;
+};
+
+export type RecruitmentPeriodNoticeContent = {
+  recruitmentGroupUid?: string | null;
+  contentType: string;
+  startAt: UtcIsoString;
+  endAt: UtcIsoString | null;
+  endless: boolean;
+};
+
+/**
+ * Returns the static period notice for a timeline content, or null when the
+ * content should not show one. `now` stays outside route-cache payloads so the
+ * ended/current wording is evaluated for each request or render.
+ */
+export function getRecruitmentPeriodNotice(
+  content: RecruitmentPeriodNoticeContent,
+  recruitmentPeriod: RecruitmentPeriod | null | undefined,
+  now: UtcIsoString,
+): string | null {
+  if (!content.recruitmentGroupUid || !recruitmentPeriod || content.endless || content.endAt === null) {
+    return null;
+  }
+
+  const periodDiffers =
+    getInstantTime(content.startAt) !== getInstantTime(recruitmentPeriod.startAt) ||
+    getInstantTime(content.endAt) !==
+      (recruitmentPeriod.endAt === null ? null : getInstantTime(recruitmentPeriod.endAt));
+
+  if (!periodDiffers) {
+    return null;
+  }
+
+  if (recruitmentPeriod.endAt !== null && getInstantTime(now) >= getInstantTime(recruitmentPeriod.endAt)) {
+    return "학생 모집은 종료되었어요";
+  }
+
+  return content.contentType === "event"
+    ? "이벤트 기간과 모집 개최 기간이 달라요"
+    : "컨텐츠 기간과 모집 개최 기간이 달라요";
+}

--- a/app/domain/recruitment-period-notice.ts
+++ b/app/domain/recruitment-period-notice.ts
@@ -23,7 +23,13 @@ export function getRecruitmentPeriodNotice(
   recruitmentPeriod: RecruitmentPeriod | null | undefined,
   now: UtcIsoString,
 ): string | null {
-  if (!content.recruitmentGroupUid || !recruitmentPeriod || content.endless || content.endAt === null) {
+  if (
+    !content.recruitmentGroupUid ||
+    !recruitmentPeriod ||
+    recruitmentPeriod.endAt === null ||
+    content.endless ||
+    content.endAt === null
+  ) {
     return null;
   }
 
@@ -36,7 +42,7 @@ export function getRecruitmentPeriodNotice(
     return null;
   }
 
-  if (recruitmentPeriod.endAt !== null && getInstantTime(now) >= getInstantTime(recruitmentPeriod.endAt)) {
+  if (getInstantTime(now) >= getInstantTime(recruitmentPeriod.endAt)) {
     return "학생 모집은 종료되었어요";
   }
 

--- a/app/models/recruitment.ts
+++ b/app/models/recruitment.ts
@@ -1,7 +1,9 @@
+import type { RecruitmentPeriod } from "~/domain/recruitment-period-notice";
 import { graphql } from "~/graphql";
 import type { RecruitmentGroupsListQuery, RecruitmentPoolStudentsQuery } from "~/graphql/graphql";
 import { runQuery } from "~/lib/baql";
 import { cacheKey, fetchSourceCached } from "~/lib/cache";
+import { toUtcIso } from "~/lib/date-time";
 
 const RECRUITMENT_GROUPS_CACHE_KEY = cacheKey("source", "recruitment-group", 1, "endAfterDays=7");
 const HISTORICAL_RECRUITMENT_GROUPS_CACHE_KEY = cacheKey("source", "recruitment-group", 1, "all");
@@ -106,6 +108,19 @@ export async function getRecruitmentGroupByUid(
   return groups.find((group) => group.uid === uid) ?? null;
 }
 
+export async function getRecruitmentGroupByUidStrict(
+  env: Env,
+  uid: string,
+  forceRefresh = false,
+): Promise<RecruitmentGroup> {
+  const group = (await fetchAllHistoricalRecruitmentGroups(env, forceRefresh)).find((item) => item.uid === uid);
+  if (!group) {
+    throw new Error(`recruitment group not found: ${uid}`);
+  }
+
+  return group;
+}
+
 export async function getActiveRecruitmentGroups(
   env: Env,
   now: Date,
@@ -132,6 +147,39 @@ export async function getRecruitmentGroupsByUids(
   const uidSet = new Set(uids);
   const groups = await getAllHistoricalRecruitmentGroups(env, forceRefresh);
   return groups.filter((group) => uidSet.has(group.uid));
+}
+
+export async function getRecruitmentGroupsByUidsStrict(
+  env: Env,
+  uids: string[],
+  forceRefresh = false,
+): Promise<RecruitmentGroup[]> {
+  const uniqueUids = [...new Set(uids)];
+  if (uniqueUids.length === 0) {
+    return [];
+  }
+
+  const groups = await fetchAllHistoricalRecruitmentGroups(env, forceRefresh);
+  const groupsByUid = new Map(groups.map((group) => [group.uid, group]));
+  const missingUids = uniqueUids.filter((uid) => !groupsByUid.has(uid));
+  if (missingUids.length > 0) {
+    throw new Error(`recruitment groups not found: ${missingUids.join(", ")}`);
+  }
+
+  return uniqueUids.map((uid) => {
+    const group = groupsByUid.get(uid);
+    if (!group) {
+      throw new Error(`recruitment group not found: ${uid}`);
+    }
+    return group;
+  });
+}
+
+export function normalizeRecruitmentGroupPeriod(group: Pick<RecruitmentGroup, "startAt" | "endAt">): RecruitmentPeriod {
+  return {
+    startAt: toUtcIso(group.startAt),
+    endAt: group.endAt ? toUtcIso(group.endAt) : null,
+  };
 }
 
 export async function getRecruitmentPoolStudents(

--- a/app/routes/events.$uid._index.tsx
+++ b/app/routes/events.$uid._index.tsx
@@ -1,12 +1,13 @@
-import { ExclamationTriangleIcon, SparklesIcon } from "@heroicons/react/24/outline";
+import { ClockIcon, SparklesIcon } from "@heroicons/react/24/outline";
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router";
 import { redirect, useLoaderData, useNavigate } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import { EventHeader, EventInfoCard, Recruitments } from "~/components/features/events";
 import { Callout, MarkdownText, SectionCard } from "~/components/primitives";
+import { useDisplayTimeZone } from "~/contexts/TimeZoneProvider";
 import { filterRecruitmentsByStudentUids, getRecruitmentFavoriteKey } from "~/domain/recruitment-identity";
 import { getRecruitmentPeriodNotice } from "~/domain/recruitment-period-notice";
-import { nowUtcIso, toUtcIso } from "~/lib/date-time";
+import { formatInstant, nowUtcIso, toUtcIso } from "~/lib/date-time";
 import { canonicalLink } from "~/lib/seo";
 import { getNestedContentComments } from "~/models/content.server";
 import {
@@ -148,6 +149,7 @@ export const meta: MetaFunction<typeof loader> = ({ loaderData, params, location
 export default function EventIndex() {
   const { eventContent, signedIn, allComments, me, eventUid, siblingEvents, livePost } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
+  const displayTimeZone = useDisplayTimeZone();
   const isLive = eventContent.type === "live";
   const recruitmentPeriodNotice = getRecruitmentPeriodNotice(
     {
@@ -160,6 +162,9 @@ export default function EventIndex() {
     eventContent.recruitmentPeriod,
     nowUtcIso(),
   );
+  const recruitmentPeriodDescription = eventContent.recruitmentPeriod?.endAt
+    ? `모집은 ${formatInstant(eventContent.recruitmentPeriod.startAt, { timeZone: displayTimeZone, format: "YYYY-MM-DD" })} ~ ${formatInstant(eventContent.recruitmentPeriod.endAt, { timeZone: displayTimeZone, format: "YYYY-MM-DD" })} 동안 진행돼요`
+    : null;
 
   return (
     <div className="w-full">
@@ -177,9 +182,13 @@ export default function EventIndex() {
       </div>
 
       {recruitmentPeriodNotice && (
-        <Callout tone="warning" Icon={ExclamationTriangleIcon} className="my-4 md:my-6">
-          {recruitmentPeriodNotice}
-        </Callout>
+        <Callout
+          tone="warning"
+          Icon={ClockIcon}
+          title="이벤트 기간과 모집 개최 기간이 달라요"
+          description={recruitmentPeriodDescription}
+          className="my-4 md:my-6"
+        />
       )}
 
       {siblingEvents.map((sibling) => (

--- a/app/routes/events.$uid._index.tsx
+++ b/app/routes/events.$uid._index.tsx
@@ -1,11 +1,12 @@
-import { SparklesIcon } from "@heroicons/react/24/outline";
+import { ExclamationTriangleIcon, SparklesIcon } from "@heroicons/react/24/outline";
 import type { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction } from "react-router";
 import { redirect, useLoaderData, useNavigate } from "react-router";
 import { getActiveSensei } from "~/auth/authenticator.server";
 import { EventHeader, EventInfoCard, Recruitments } from "~/components/features/events";
-import { MarkdownText, SectionCard } from "~/components/primitives";
+import { Callout, MarkdownText, SectionCard } from "~/components/primitives";
 import { filterRecruitmentsByStudentUids, getRecruitmentFavoriteKey } from "~/domain/recruitment-identity";
-import { toUtcIso } from "~/lib/date-time";
+import { getRecruitmentPeriodNotice } from "~/domain/recruitment-period-notice";
+import { nowUtcIso, toUtcIso } from "~/lib/date-time";
 import { canonicalLink } from "~/lib/seo";
 import { getNestedContentComments } from "~/models/content.server";
 import {
@@ -15,7 +16,7 @@ import {
   unfavoriteStudent,
 } from "~/models/favorite-students";
 import { getPostByTimelineContentUid } from "~/models/post";
-import { getRecruitmentGroupByUid } from "~/models/recruitment";
+import { getRecruitmentGroupByUidStrict, normalizeRecruitmentGroupPeriod } from "~/models/recruitment";
 import { getTimelineContent, getTimelineContentsByRecruitmentGroupUids } from "~/models/timeline-content.server";
 import EventComment from "./events.$uid._components/EventComment";
 
@@ -32,7 +33,7 @@ export const loader = async ({ params, context, request }: LoaderFunctionArgs) =
   }
 
   const recruitmentGroup = content.recruitmentGroupUid
-    ? await getRecruitmentGroupByUid(env, content.recruitmentGroupUid)
+    ? await getRecruitmentGroupByUidStrict(env, content.recruitmentGroupUid)
     : null;
   const recruitments = filterRecruitmentsByStudentUids(
     recruitmentGroup?.recruitments ?? [],
@@ -52,6 +53,8 @@ export const loader = async ({ params, context, request }: LoaderFunctionArgs) =
     runType: content.runType,
     endless: content.endless,
     videos: content.videos,
+    recruitmentGroupUid: content.recruitmentGroupUid,
+    recruitmentPeriod: recruitmentGroup ? normalizeRecruitmentGroupPeriod(recruitmentGroup) : null,
     recruitments,
   };
 
@@ -146,6 +149,17 @@ export default function EventIndex() {
   const { eventContent, signedIn, allComments, me, eventUid, siblingEvents, livePost } = useLoaderData<typeof loader>();
   const navigate = useNavigate();
   const isLive = eventContent.type === "live";
+  const recruitmentPeriodNotice = getRecruitmentPeriodNotice(
+    {
+      recruitmentGroupUid: eventContent.recruitmentGroupUid,
+      contentType: eventContent.type,
+      startAt: eventContent.since,
+      endAt: eventContent.until,
+      endless: eventContent.endless,
+    },
+    eventContent.recruitmentPeriod,
+    nowUtcIso(),
+  );
 
   return (
     <div className="w-full">
@@ -161,6 +175,12 @@ export default function EventIndex() {
           videos={eventContent.videos}
         />
       </div>
+
+      {recruitmentPeriodNotice && (
+        <Callout tone="warning" Icon={ExclamationTriangleIcon} className="my-4 md:my-6">
+          {recruitmentPeriodNotice}
+        </Callout>
+      )}
 
       {siblingEvents.map((sibling) => (
         <EventInfoCard

--- a/app/routes/futures.tsx
+++ b/app/routes/futures.tsx
@@ -63,6 +63,7 @@ export const loader = async ({ request, context }: LoaderFunctionArgs) => {
       runType: content.runType,
       contentUid: content.contentUid,
       recruitmentGroupUid: content.recruitmentGroupUid,
+      recruitmentPeriod: content.recruitmentPeriod,
       imageUrl: content.imageUrl,
       confirmed: content.confirmed,
       isSpoiler: content.isSpoiler,
@@ -168,6 +169,7 @@ type FutureContentForView = Pick<
   | "isSpoiler"
   | "tags"
   | "recruitments"
+  | "recruitmentPeriod"
   | "raidInfo"
 >;
 type FutureContentsLoaderContent = FutureContentForView & Pick<FutureContent, "contentUid" | "recruitmentGroupUid">;
@@ -595,6 +597,7 @@ export default function FutureContents() {
           name: common.raidInfo ? common.raidInfo.name : content.name,
           imageUrl: content.imageUrl,
           recruitmentGroupUid: content.recruitmentGroupUid,
+          recruitmentPeriod: content.recruitmentPeriod,
           recruitments: content.recruitments.length > 0 ? content.recruitments : undefined,
           showStudentAnalysisFeatureBanner: content.uid === studentAnalysisFeatureBannerContentUid,
           showPendingStudentFavoriteFeatureBanner: hasPendingStudentRecruitment(content),
@@ -693,6 +696,7 @@ export default function FutureContents() {
             signedIn={signedIn}
             recruitmentStudentMobileGrid={5}
             showFeatureBanners={view === "timeline"}
+            showRecruitmentPeriodNotice={view === "timeline"}
             revealedSpoilerContentUids={revealedSpoilerContentUids}
             onRevealSpoiler={revealSpoiler}
             onHideSpoiler={hideSpoiler}

--- a/app/views/futures.ts
+++ b/app/views/futures.ts
@@ -1,9 +1,14 @@
 import { filterRecruitmentsByStudentUids, getRecruitmentFavoriteKey } from "~/domain/recruitment-identity";
+import type { RecruitmentPeriod } from "~/domain/recruitment-period-notice";
 import type { Attack, Defense, RecruitmentTypeEnum } from "~/graphql/graphql";
 import { cacheKey, fetchRouteCached } from "~/lib/cache";
 import { isInstantAfter, normalizeInstant, nowUtcIso, toUtcIso, type UtcIsoString } from "~/lib/date-time";
 import type { Role } from "~/models/content.d";
-import { type getRecruitmentGroupByUid, getRecruitmentGroupsByUids } from "~/models/recruitment";
+import {
+  type getRecruitmentGroupByUid,
+  getRecruitmentGroupsByUidsStrict,
+  normalizeRecruitmentGroupPeriod,
+} from "~/models/recruitment";
 import type { TimelineContent } from "~/models/timeline-content";
 import { getTimelineContents } from "~/models/timeline-content.server";
 import { getUpcomingRaidContents, type RaidInfo } from "./raid-content";
@@ -27,6 +32,7 @@ export type RecruitmentInfo = {
 
 export type FutureContent = TimelineContent & {
   recruitments: RecruitmentInfo[];
+  recruitmentPeriod: RecruitmentPeriod | null;
   raidInfo?: RaidInfo;
 };
 
@@ -44,6 +50,14 @@ export function normalizeFutureContentDates(content: FutureContent): FutureConte
     startAt: normalizeInstantValue(content.startAt) ?? normalizeInstant(content.startAt),
     endAt: normalizeInstantValue(content.endAt),
     syncedAt: normalizeInstantValue(content.syncedAt),
+    recruitmentPeriod: content.recruitmentPeriod
+      ? {
+          startAt:
+            normalizeInstantValue(content.recruitmentPeriod.startAt) ??
+            normalizeInstant(content.recruitmentPeriod.startAt),
+          endAt: normalizeInstantValue(content.recruitmentPeriod.endAt),
+        }
+      : null,
     recruitments: content.recruitments.map((recruitment) => ({
       ...recruitment,
       since: normalizeInstantValue(recruitment.since) ?? normalizeInstant(recruitment.since),
@@ -86,7 +100,7 @@ export async function getFutureContents(
   const allEnriched = await fetchRouteCached(
     env,
     ctx,
-    cacheKey("route", "futures", 2, "all"),
+    cacheKey("route", "futures", 3, "all"),
     async () => {
       const [contents, upcomingRaidContents] = await Promise.all([
         getTimelineContents(env, nowUtcIso(), { ctx }),
@@ -96,21 +110,37 @@ export async function getFutureContents(
       const recruitmentGroupUids = contents
         .map((content) => content.recruitmentGroupUid)
         .filter((uid) => uid !== null) as string[];
-      const recruitmentGroups = await getRecruitmentGroupsByUids(env, recruitmentGroupUids, forceRefresh);
+      const recruitmentGroups = await getRecruitmentGroupsByUidsStrict(env, recruitmentGroupUids, forceRefresh);
       const recruitmentGroupMap = new Map(recruitmentGroups.map((group) => [group.uid, group]));
 
       return Promise.all(
         contents.map(async (content) => {
+          const group = content.recruitmentGroupUid
+            ? (recruitmentGroupMap.get(content.recruitmentGroupUid) ?? null)
+            : null;
+          if (content.recruitmentGroupUid && !group) {
+            throw new Error(`recruitment group not found: ${content.recruitmentGroupUid}`);
+          }
+          const recruitmentPeriod = group ? normalizeRecruitmentGroupPeriod(group) : null;
+
           if (content.contentType === "raid") {
-            return { ...content, recruitments: [], raidInfo: upcomingRaidMap.get(content.uid)?.raidInfo };
+            return {
+              ...content,
+              recruitments: [],
+              recruitmentPeriod,
+              raidInfo: upcomingRaidMap.get(content.uid)?.raidInfo,
+            };
           }
 
-          if (content.recruitmentGroupUid) {
-            const group = recruitmentGroupMap.get(content.recruitmentGroupUid) ?? null;
-            return { ...content, recruitments: toRecruitmentInfos(group, content.recruitmentStudentUids) };
+          if (group) {
+            return {
+              ...content,
+              recruitments: toRecruitmentInfos(group, content.recruitmentStudentUids),
+              recruitmentPeriod,
+            };
           }
 
-          return { ...content, recruitments: [] };
+          return { ...content, recruitments: [], recruitmentPeriod };
         }),
       );
     },

--- a/test/app/components/features/contents/recruitment-period-notice.test.tsx
+++ b/test/app/components/features/contents/recruitment-period-notice.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "@jest/globals";
+import { type ComponentProps, createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import ContentTimeline from "~/components/features/contents/ContentTimeline";
+import ContentTimelineCompact from "~/components/features/contents/ContentTimelineCompact";
+import { ContentTimelineItem, type ContentTimelineItemProps } from "~/components/features/contents/ContentTimelineItem";
+import { StudentCardPopupProvider } from "~/contexts/StudentCardPopupProvider";
+import { TimeZoneProvider } from "~/contexts/TimeZoneProvider";
+import type { RecruitmentPeriod } from "~/domain/recruitment-period-notice";
+
+const recruitmentPeriod: RecruitmentPeriod = {
+  startAt: "2030-01-11T00:00:00.000Z",
+  endAt: "2030-01-21T00:00:00.000Z",
+};
+
+const contentDates = {
+  since: "2030-01-10T00:00:00.000Z",
+  until: "2030-01-20T00:00:00.000Z",
+};
+
+function itemProps(overrides: Partial<ContentTimelineItemProps> = {}): ContentTimelineItemProps {
+  return {
+    uid: "future-event",
+    name: "미래 이벤트",
+    contentType: "event",
+    runType: "first",
+    endless: false,
+    ...contentDates,
+    link: "/events/future-event",
+    tags: [],
+    recruitmentGroupUid: "group-a",
+    recruitmentPeriod,
+    signedIn: false,
+    ...overrides,
+  };
+}
+
+function renderItem(overrides: Partial<ContentTimelineItemProps> = {}) {
+  return renderToStaticMarkup(
+    createElement(
+      MemoryRouter,
+      null,
+      createElement(
+        TimeZoneProvider,
+        { timeZone: "UTC" } as ComponentProps<typeof TimeZoneProvider>,
+        createElement(StudentCardPopupProvider, null, createElement(ContentTimelineItem, itemProps(overrides))),
+      ),
+    ),
+  );
+}
+
+function compactContent(overrides: Record<string, unknown> = {}) {
+  return {
+    uid: "future-event",
+    name: "미래 이벤트",
+    since: contentDates.since,
+    until: contentDates.until,
+    startAt: contentDates.since,
+    endAt: contentDates.until,
+    endless: false,
+    runType: "first" as const,
+    recruitmentGroupUid: "group-a",
+    recruitmentPeriod,
+    link: "/events/future-event",
+    contentType: "event" as const,
+    isSpoiler: false,
+    tags: [],
+    recruitments: [],
+    ...overrides,
+  };
+}
+
+describe("recruitment period notices in timeline views", () => {
+  it("renders the period warning before existing feature banners without a dismiss action", () => {
+    const markup = renderItem({ showStudentAnalysisFeatureBanner: true });
+
+    const periodNoticeIndex = markup.indexOf("이벤트 기간과 모집 개최 기간이 달라요");
+    const featureBannerIndex = markup.indexOf("학생부에서 통계 분석을 보고 모집 여부를 판단해보세요");
+
+    expect(periodNoticeIndex).toBeGreaterThanOrEqual(0);
+    expect(featureBannerIndex).toBeGreaterThan(periodNoticeIndex);
+    expect(markup).toContain("from-amber-50");
+    expect(markup).toContain("from-green-50");
+    expect(markup).not.toContain("배너 닫기");
+  });
+
+  it("renders a compact warning below the title when the filtered student list is empty", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        MemoryRouter,
+        null,
+        createElement(
+          TimeZoneProvider,
+          { timeZone: "UTC" } as ComponentProps<typeof TimeZoneProvider>,
+          createElement(
+            StudentCardPopupProvider,
+            null,
+            createElement(ContentTimelineCompact, {
+              contents: [compactContent()],
+              favoritedCounts: [],
+            }),
+          ),
+        ),
+      ),
+    );
+
+    const titleIndex = markup.indexOf("미래 이벤트");
+    const noticeIndex = markup.indexOf("이벤트 기간과 모집 개최 기간이 달라요");
+
+    expect(noticeIndex).toBeGreaterThan(titleIndex);
+    expect(markup).toContain("text-amber-600");
+    expect(markup).toContain('aria-hidden="true"');
+    expect(markup).not.toContain('role="alert"');
+  });
+
+  it("omits the warning when ContentTimeline is used for the table view", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        MemoryRouter,
+        null,
+        createElement(
+          TimeZoneProvider,
+          { timeZone: "UTC" } as ComponentProps<typeof TimeZoneProvider>,
+          createElement(
+            StudentCardPopupProvider,
+            null,
+            createElement(ContentTimeline, {
+              contents: [compactContent()],
+              favoritedCounts: [],
+              signedIn: false,
+              showRecruitmentPeriodNotice: false,
+            }),
+          ),
+        ),
+      ),
+    );
+
+    expect(markup).not.toContain("이벤트 기간과 모집 개최 기간이 달라요");
+  });
+});

--- a/test/app/components/features/contents/recruitment-period-notice.test.tsx
+++ b/test/app/components/features/contents/recruitment-period-notice.test.tsx
@@ -72,7 +72,7 @@ function compactContent(overrides: Record<string, unknown> = {}) {
 }
 
 describe("recruitment period notices in timeline views", () => {
-  it("renders the period warning before existing feature banners without a dismiss action", () => {
+  it("renders the period warning with a detail button before existing feature banners and without a dismiss action", () => {
     const markup = renderItem({ showStudentAnalysisFeatureBanner: true });
 
     const periodNoticeIndex = markup.indexOf("이벤트 기간과 모집 개최 기간이 달라요");
@@ -82,6 +82,9 @@ describe("recruitment period notices in timeline views", () => {
     expect(featureBannerIndex).toBeGreaterThan(periodNoticeIndex);
     expect(markup).toContain("from-amber-50");
     expect(markup).toContain("from-green-50");
+    expect(markup).toContain("<button");
+    expect(markup).toContain(">자세히</button>");
+    expect(markup).toContain("bg-amber-600/10");
     expect(markup).not.toContain("배너 닫기");
   });
 

--- a/test/app/domain/recruitment-period-notice.test.ts
+++ b/test/app/domain/recruitment-period-notice.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+  getRecruitmentPeriodNotice,
+  type RecruitmentPeriod,
+  type RecruitmentPeriodNoticeContent,
+} from "~/domain/recruitment-period-notice";
+
+const now = "2026-09-07T00:00:00.000Z";
+
+function content(overrides: Partial<RecruitmentPeriodNoticeContent> = {}): RecruitmentPeriodNoticeContent {
+  return {
+    recruitmentGroupUid: "group-a",
+    contentType: "event",
+    startAt: "2026-09-10T00:00:00.000Z",
+    endAt: "2026-09-20T00:00:00.000Z",
+    endless: false,
+    ...overrides,
+  };
+}
+
+function period(overrides: Partial<RecruitmentPeriod> = {}): RecruitmentPeriod {
+  return {
+    startAt: "2026-09-10T00:00:00.000Z",
+    endAt: "2026-09-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("getRecruitmentPeriodNotice", () => {
+  it("compares exact instants rather than timestamp formatting", () => {
+    expect(
+      getRecruitmentPeriodNotice(
+        content({ startAt: "2026-09-10T09:00:00+09:00", endAt: "2026-09-20T09:00:00+09:00" }),
+        period(),
+        now,
+      ),
+    ).toBeNull();
+  });
+
+  it("notices a content start instant mismatch before recruitment ends", () => {
+    expect(getRecruitmentPeriodNotice(content({ startAt: "2026-09-11T00:00:00.000Z" }), period(), now)).toBe(
+      "이벤트 기간과 모집 개최 기간이 달라요",
+    );
+  });
+
+  it("uses the general wording for a non-event content end mismatch", () => {
+    expect(
+      getRecruitmentPeriodNotice(
+        content({ contentType: "main_story", endAt: "2026-09-21T00:00:00.000Z" }),
+        period(),
+        now,
+      ),
+    ).toBe("컨텐츠 기간과 모집 개최 기간이 달라요");
+  });
+
+  it("uses the ended wording at and after a finite recruitment end", () => {
+    const mismatched = content({ startAt: "2026-09-11T00:00:00.000Z" });
+
+    expect(getRecruitmentPeriodNotice(mismatched, period(), "2026-09-20T00:00:00.000Z")).toBe(
+      "학생 모집은 종료되었어요",
+    );
+    expect(getRecruitmentPeriodNotice(mismatched, period(), "2026-09-21T00:00:00.000Z")).toBe(
+      "학생 모집은 종료되었어요",
+    );
+  });
+
+  it("uses the mismatch wording for a recruitment without an end", () => {
+    expect(
+      getRecruitmentPeriodNotice(
+        content({ contentType: "mini_story", startAt: "2026-09-11T00:00:00.000Z" }),
+        period({ endAt: null }),
+        now,
+      ),
+    ).toBe("컨텐츠 기간과 모집 개최 기간이 달라요");
+  });
+
+  it.each([
+    ["no recruitment group uid", content({ recruitmentGroupUid: null }), period()],
+    ["missing recruitment group", content(), null],
+    ["content without an end", content({ endAt: null }), period({ endAt: null })],
+    ["endless content", content({ endless: true }), period({ startAt: "2026-09-11T00:00:00.000Z" })],
+    ["matching period", content(), period()],
+  ])("does not notice %s", (_label, input, recruitmentPeriod) => {
+    expect(getRecruitmentPeriodNotice(input, recruitmentPeriod, now)).toBeNull();
+  });
+
+  it.each([
+    "pray-ball-rerun",
+    "hyakuyori-izuru-ichirinnno-rerun",
+    "pandemonium-cruise",
+  ])("notices the approved future fixture %s", (_uid) => {
+    expect(
+      getRecruitmentPeriodNotice(
+        content({ startAt: "2026-09-08T00:00:00.000Z" }),
+        period({ startAt: "2026-09-09T00:00:00.000Z" }),
+        now,
+      ),
+    ).toBe("이벤트 기간과 모집 개최 기간이 달라요");
+  });
+
+  it.each([
+    "hatsune-miku",
+    "code-box",
+    "natsuzora-no-yakusoku",
+    "art-for-someone",
+  ])("uses the ended wording for the approved historical fixture %s", (_uid) => {
+    expect(
+      getRecruitmentPeriodNotice(
+        content({ startAt: "2025-09-08T00:00:00.000Z", endAt: "2025-09-20T00:00:00.000Z" }),
+        period({ startAt: "2025-09-09T00:00:00.000Z", endAt: "2025-09-19T00:00:00.000Z" }),
+        now,
+      ),
+    ).toBe("학생 모집은 종료되었어요");
+  });
+
+  it("does not notice the approved endless archive fixture", () => {
+    expect(
+      getRecruitmentPeriodNotice(
+        content({ endless: true, startAt: "2025-09-01T00:00:00.000Z", endAt: "2025-09-30T00:00:00.000Z" }),
+        period({ startAt: "2025-09-02T00:00:00.000Z", endAt: null }),
+        now,
+      ),
+    ).toBeNull();
+  });
+});

--- a/test/app/domain/recruitment-period-notice.test.ts
+++ b/test/app/domain/recruitment-period-notice.test.ts
@@ -64,19 +64,10 @@ describe("getRecruitmentPeriodNotice", () => {
     );
   });
 
-  it("uses the mismatch wording for a recruitment without an end", () => {
-    expect(
-      getRecruitmentPeriodNotice(
-        content({ contentType: "mini_story", startAt: "2026-09-11T00:00:00.000Z" }),
-        period({ endAt: null }),
-        now,
-      ),
-    ).toBe("컨텐츠 기간과 모집 개최 기간이 달라요");
-  });
-
   it.each([
     ["no recruitment group uid", content({ recruitmentGroupUid: null }), period()],
     ["missing recruitment group", content(), null],
+    ["recruitment without an end", content({ startAt: "2026-09-11T00:00:00.000Z" }), period({ endAt: null })],
     ["content without an end", content({ endAt: null }), period({ endAt: null })],
     ["endless content", content({ endless: true }), period({ startAt: "2026-09-11T00:00:00.000Z" })],
     ["matching period", content(), period()],

--- a/test/app/models/future-content.test.ts
+++ b/test/app/models/future-content.test.ts
@@ -4,6 +4,8 @@ import { type FutureContent, normalizeFutureContentDates, toRecruitmentInfos } f
 jest.mock("~/models/recruitment", () => ({
   getRecruitmentGroupByUid: jest.fn(),
   getRecruitmentGroupsByUids: jest.fn(),
+  getRecruitmentGroupsByUidsStrict: jest.fn(),
+  normalizeRecruitmentGroupPeriod: jest.fn(),
 }));
 
 jest.mock("~/domain/recruitment-identity", () => ({
@@ -35,7 +37,11 @@ describe("normalizeFutureContentDates", () => {
       runType: "first",
       occurrence: null,
       contentUid: "202604-hieronymus",
-      recruitmentGroupUid: null,
+      recruitmentGroupUid: "group-a",
+      recruitmentPeriod: {
+        startAt: "2026-03-31T11:00:00+09:00",
+        endAt: "2026-04-07T11:00:00+09:00",
+      },
       confirmed: true,
       isSpoiler: false,
       tags: [],
@@ -68,6 +74,10 @@ describe("normalizeFutureContentDates", () => {
     expect(normalized.startAt).toBe("2026-03-31T02:00:00.000Z");
     expect(normalized.endAt).toBe("2026-04-06T19:00:00.000Z");
     expect(normalized.syncedAt).toBe("2026-03-29T09:20:22.385Z");
+    expect(normalized.recruitmentPeriod).toEqual({
+      startAt: "2026-03-31T02:00:00.000Z",
+      endAt: "2026-04-07T02:00:00.000Z",
+    });
     expect(normalized.recruitments[0].since).toBe("2026-03-31T02:00:00.000Z");
     expect(normalized.recruitments[0].until).toBe("2026-04-07T02:00:00.000Z");
   });

--- a/test/app/models/recruitment.test.ts
+++ b/test/app/models/recruitment.test.ts
@@ -3,7 +3,10 @@ import { runQuery } from "~/lib/baql";
 import {
   getAllHistoricalRecruitmentGroups,
   getRecruitmentGroupByUid,
+  getRecruitmentGroupByUidStrict,
   getRecruitmentGroupsByUids,
+  getRecruitmentGroupsByUidsStrict,
+  normalizeRecruitmentGroupPeriod,
   warmRecruitmentCache,
 } from "../../../app/models/recruitment";
 
@@ -15,6 +18,7 @@ type ModelEnv = Env;
 const mockedRunQuery = runQuery as unknown as {
   mockReset: () => void;
   mockResolvedValueOnce: (value: unknown) => unknown;
+  mockRejectedValueOnce: (value: unknown) => unknown;
   mockImplementation: (fn: () => Promise<unknown>) => unknown;
 };
 
@@ -227,5 +231,81 @@ describe("recruitment historical lookups", () => {
       endAfter: null,
       uids: null,
     });
+  });
+
+  it("normalizes recruitment group periods to UTC ISO strings", () => {
+    expect(
+      normalizeRecruitmentGroupPeriod({
+        startAt: "2026-03-10T11:00:00+09:00" as never,
+        endAt: "2026-03-24T11:00:00+09:00" as never,
+      }),
+    ).toEqual({
+      startAt: "2026-03-10T02:00:00.000Z",
+      endAt: "2026-03-24T02:00:00.000Z",
+    });
+  });
+
+  it("throws when a strict single-group lookup cannot resolve the requested uid", async () => {
+    mockedRunQuery.mockResolvedValueOnce(createResult([]));
+
+    await expect(getRecruitmentGroupByUidStrict(createEnv(), "missing-group")).rejects.toThrow(
+      "recruitment group not found: missing-group",
+    );
+  });
+
+  it("propagates BAQL failures from a strict single-group lookup", async () => {
+    const error = new Error("BAQL unavailable");
+    mockedRunQuery.mockRejectedValueOnce(error);
+
+    await expect(getRecruitmentGroupByUidStrict(createEnv(), "group-a")).rejects.toBe(error);
+  });
+
+  it("throws when a strict multi-group lookup has a missing uid", async () => {
+    mockedRunQuery.mockResolvedValueOnce(
+      createResult([
+        {
+          uid: "present-group",
+          startAt: "2026-03-10T00:00:00Z",
+          endAt: null,
+          contentType: "event",
+          contentUid: null,
+          recruitmentType: "usual",
+          recruitments: [],
+        },
+      ]),
+    );
+
+    await expect(getRecruitmentGroupsByUidsStrict(createEnv(), ["present-group", "missing-group"])).rejects.toThrow(
+      "recruitment groups not found: missing-group",
+    );
+  });
+
+  it("returns strict groups in requested uid order", async () => {
+    const groups = [
+      {
+        uid: "group-b",
+        startAt: "2026-03-11T00:00:00Z",
+        endAt: null,
+        contentType: "event",
+        contentUid: null,
+        recruitmentType: "usual",
+        recruitments: [],
+      },
+      {
+        uid: "group-a",
+        startAt: "2026-03-10T00:00:00Z",
+        endAt: null,
+        contentType: "event",
+        contentUid: null,
+        recruitmentType: "usual",
+        recruitments: [],
+      },
+    ];
+    mockedRunQuery.mockResolvedValueOnce(createResult(groups));
+
+    await expect(getRecruitmentGroupsByUidsStrict(createEnv(), ["group-a", "group-b", "group-a"])).resolves.toEqual([
+      groups[1],
+      groups[0],
+    ]);
   });
 });

--- a/test/app/routes/events-recruitment-period-notice.test.tsx
+++ b/test/app/routes/events-recruitment-period-notice.test.tsx
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter, useLoaderData, useNavigate } from "react-router";
+import { getActiveSensei } from "~/auth/authenticator.server";
+import { getNestedContentComments } from "~/models/content.server";
+import { getFavoritedCounts, getUserFavoritedStudents } from "~/models/favorite-students";
+import { getPostByTimelineContentUid } from "~/models/post";
+import { getRecruitmentGroupByUidStrict, normalizeRecruitmentGroupPeriod } from "~/models/recruitment";
+import { getTimelineContent, getTimelineContentsByRecruitmentGroupUids } from "~/models/timeline-content.server";
+import EventIndex, { loader } from "~/routes/events.$uid._index";
+
+jest.mock("react-router", () => {
+  const actual = jest.requireActual<typeof import("react-router")>("react-router");
+  return {
+    ...actual,
+    useLoaderData: jest.fn(),
+    useNavigate: jest.fn(),
+  };
+});
+
+jest.mock("~/auth/authenticator.server", () => ({
+  getActiveSensei: jest.fn(),
+}));
+
+jest.mock("~/components/features/events", () => {
+  const { createElement } = jest.requireActual<typeof import("react")>("react");
+  return {
+    EventHeader: () => createElement("div", { "data-testid": "event-header" }, "event header"),
+    EventInfoCard: ({ title }: { title: string }) => createElement("div", { "data-testid": "sibling" }, title),
+    Recruitments: () => createElement("div", { "data-testid": "recruitments" }, "recruitments"),
+  };
+});
+
+jest.mock("~/models/content.server", () => ({
+  getNestedContentComments: jest.fn(),
+}));
+
+jest.mock("~/models/favorite-students", () => ({
+  getFavoritedCounts: jest.fn(),
+  getUserFavoritedStudents: jest.fn(),
+  favoriteStudent: jest.fn(),
+  unfavoriteStudent: jest.fn(),
+}));
+
+jest.mock("~/models/post", () => ({
+  getPostByTimelineContentUid: jest.fn(),
+}));
+
+jest.mock("~/models/recruitment", () => ({
+  getRecruitmentGroupByUidStrict: jest.fn(),
+  normalizeRecruitmentGroupPeriod: jest.fn(),
+}));
+
+jest.mock("~/models/timeline-content.server", () => ({
+  getTimelineContent: jest.fn(),
+  getTimelineContentsByRecruitmentGroupUids: jest.fn(),
+}));
+
+jest.mock("../../../app/routes/events.$uid._components/EventComment", () => {
+  const { createElement } = jest.requireActual<typeof import("react")>("react");
+  return function MockEventComment() {
+    return createElement("div", { "data-testid": "comments" }, "comments");
+  };
+});
+
+const env = {} as Env;
+const ctx = {} as ExecutionContext;
+const mockedUseLoaderData = useLoaderData as jest.MockedFunction<typeof useLoaderData>;
+const mockedUseNavigate = useNavigate as jest.MockedFunction<typeof useNavigate>;
+const mockedGetActiveSensei = getActiveSensei as jest.MockedFunction<typeof getActiveSensei>;
+const mockedGetNestedContentComments = getNestedContentComments as jest.MockedFunction<typeof getNestedContentComments>;
+const mockedGetFavoritedCounts = getFavoritedCounts as jest.MockedFunction<typeof getFavoritedCounts>;
+const mockedGetUserFavoritedStudents = getUserFavoritedStudents as jest.MockedFunction<typeof getUserFavoritedStudents>;
+const mockedGetPostByTimelineContentUid = getPostByTimelineContentUid as jest.MockedFunction<
+  typeof getPostByTimelineContentUid
+>;
+const mockedGetRecruitmentGroupByUidStrict = getRecruitmentGroupByUidStrict as jest.MockedFunction<
+  typeof getRecruitmentGroupByUidStrict
+>;
+const mockedNormalizeRecruitmentGroupPeriod = normalizeRecruitmentGroupPeriod as jest.MockedFunction<
+  typeof normalizeRecruitmentGroupPeriod
+>;
+const mockedGetTimelineContent = getTimelineContent as jest.MockedFunction<typeof getTimelineContent>;
+const mockedGetTimelineContentsByRecruitmentGroupUids =
+  getTimelineContentsByRecruitmentGroupUids as jest.MockedFunction<typeof getTimelineContentsByRecruitmentGroupUids>;
+
+const recruitmentPeriod = {
+  startAt: "2030-01-11T00:00:00.000Z",
+  endAt: "2030-01-21T00:00:00.000Z",
+};
+
+const timelineContent = {
+  uid: "future-event",
+  name: "미래 이벤트",
+  nameI18n: {},
+  startAt: "2030-01-10T00:00:00.000Z",
+  endAt: "2030-01-20T00:00:00.000Z",
+  endless: false,
+  imageUrl: null,
+  videos: [],
+  contentType: "event",
+  runType: "first",
+  occurrence: null,
+  contentUid: "event-1",
+  shopContentUid: null,
+  recruitmentGroupUid: "group-a",
+  recruitmentStudentUids: null,
+  confirmed: true,
+  isSpoiler: false,
+  tags: [],
+  earnablePyroxene: null,
+  syncedAt: "2029-12-01T00:00:00.000Z",
+};
+
+const recruitmentGroup = {
+  uid: "group-a",
+  startAt: "2030-01-11T00:00:00.000Z",
+  endAt: "2030-01-21T00:00:00.000Z",
+  recruitments: [],
+};
+
+function loaderArgs() {
+  return {
+    params: { uid: "future-event" },
+    request: new Request("https://mollulog.net/events/future-event"),
+    context: { cloudflare: { env, ctx } },
+  } as never;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetActiveSensei.mockResolvedValue(null);
+  mockedGetNestedContentComments.mockResolvedValue([] as never);
+  mockedGetFavoritedCounts.mockResolvedValue([]);
+  mockedGetUserFavoritedStudents.mockResolvedValue([]);
+  mockedGetPostByTimelineContentUid.mockResolvedValue(null);
+  mockedGetTimelineContent.mockResolvedValue(timelineContent as never);
+  mockedGetRecruitmentGroupByUidStrict.mockResolvedValue(recruitmentGroup as never);
+  mockedNormalizeRecruitmentGroupPeriod.mockReturnValue(recruitmentPeriod);
+  mockedGetTimelineContentsByRecruitmentGroupUids.mockResolvedValue([] as never);
+  mockedUseNavigate.mockReturnValue((() => undefined) as ReturnType<typeof useNavigate>);
+});
+
+describe("event recruitment period notice loader", () => {
+  it("includes the normalized recruitment period while preserving the filtered recruitment data", async () => {
+    const result = await loader(loaderArgs());
+
+    expect(result.eventContent).toMatchObject({
+      recruitmentGroupUid: "group-a",
+      recruitmentPeriod,
+      recruitments: [],
+    });
+    expect(mockedGetRecruitmentGroupByUidStrict).toHaveBeenCalledWith(env, "group-a");
+    expect(mockedNormalizeRecruitmentGroupPeriod).toHaveBeenCalledWith(recruitmentGroup as never);
+  });
+
+  it("propagates a strict recruitment lookup failure", async () => {
+    const error = new Error("BAQL unavailable");
+    mockedGetRecruitmentGroupByUidStrict.mockRejectedValue(error);
+
+    await expect(loader(loaderArgs())).rejects.toBe(error);
+  });
+});
+
+describe("event recruitment period notice presentation", () => {
+  it("renders the warning directly after EventHeader and before sibling guidance", () => {
+    mockedUseLoaderData.mockReturnValue({
+      eventContent: {
+        name: "미래 이벤트",
+        since: "2030-01-10T00:00:00.000Z",
+        until: "2030-01-20T00:00:00.000Z",
+        imageUrl: null,
+        type: "event",
+        runType: "first",
+        endless: false,
+        videos: [],
+        recruitmentGroupUid: "group-a",
+        recruitmentPeriod,
+        recruitments: [],
+      },
+      signedIn: false,
+      allComments: [],
+      me: null,
+      eventUid: "future-event",
+      siblingEvents: [{ uid: "sibling-event", name: "동시 개최 이벤트" }],
+      livePost: null,
+    } as never);
+
+    const markup = renderToStaticMarkup(createElement(MemoryRouter, null, createElement(EventIndex)));
+    const headerIndex = markup.indexOf('data-testid="event-header"');
+    const noticeIndex = markup.indexOf("이벤트 기간과 모집 개최 기간이 달라요");
+    const siblingIndex = markup.indexOf("모집 동시 개최");
+
+    expect(headerIndex).toBeGreaterThanOrEqual(0);
+    expect(noticeIndex).toBeGreaterThan(headerIndex);
+    expect(siblingIndex).toBeGreaterThan(noticeIndex);
+    expect(markup).toContain("bg-amber-500/10");
+    expect(markup).not.toContain('role="alert"');
+  });
+});

--- a/test/app/routes/events-recruitment-period-notice.test.tsx
+++ b/test/app/routes/events-recruitment-period-notice.test.tsx
@@ -195,6 +195,7 @@ describe("event recruitment period notice presentation", () => {
     expect(headerIndex).toBeGreaterThanOrEqual(0);
     expect(noticeIndex).toBeGreaterThan(headerIndex);
     expect(siblingIndex).toBeGreaterThan(noticeIndex);
+    expect(markup).toContain("모집은 2030-01-11 ~ 2030-01-21 동안 진행돼요");
     expect(markup).toContain("bg-amber-500/10");
     expect(markup).not.toContain('role="alert"');
   });

--- a/test/app/routes/futures.test.ts
+++ b/test/app/routes/futures.test.ts
@@ -148,4 +148,41 @@ describe("futures loader data source routing", () => {
     });
     expect(span.setAttribute).toHaveBeenCalledWith("commentSummariesAvailable", false);
   });
+
+  it("passes the normalized recruitment period through the loader without caching a notice", async () => {
+    mockedGetActiveSensei.mockResolvedValue(null);
+    mockedGetFutureContents.mockResolvedValue([
+      {
+        uid: "future-event",
+        name: "미래 이벤트",
+        startAt: "2030-01-10T00:00:00.000Z",
+        endAt: "2030-01-20T00:00:00.000Z",
+        endless: false,
+        contentType: "event",
+        runType: "first",
+        contentUid: "event-1",
+        recruitmentGroupUid: "group-a",
+        recruitmentPeriod: {
+          startAt: "2030-01-11T00:00:00.000Z",
+          endAt: "2030-01-21T00:00:00.000Z",
+        },
+        imageUrl: null,
+        confirmed: true,
+        isSpoiler: false,
+        tags: [],
+        recruitments: [],
+      },
+    ] as never);
+
+    const result = await loader(createLoaderArgs());
+
+    expect(result.contents[0]).toMatchObject({
+      recruitmentGroupUid: "group-a",
+      recruitmentPeriod: {
+        startAt: "2030-01-11T00:00:00.000Z",
+        endAt: "2030-01-21T00:00:00.000Z",
+      },
+    });
+    expect(result.contents[0]).not.toHaveProperty("recruitmentPeriodNotice");
+  });
 });

--- a/test/app/views/futures.test.ts
+++ b/test/app/views/futures.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { fetchRouteCached } from "~/lib/cache";
+import { getRecruitmentGroupsByUidsStrict, normalizeRecruitmentGroupPeriod } from "~/models/recruitment";
+import { getTimelineContents } from "~/models/timeline-content.server";
+import { getFutureContents } from "~/views/futures";
+import { getUpcomingRaidContents } from "~/views/raid-content";
+
+jest.mock("~/lib/cache", () => ({
+  cacheKey: jest.fn(
+    (category: string, domain: string, version: number, query: string) =>
+      `${category}::${domain}::v${version}::${query}`,
+  ),
+  fetchRouteCached: jest.fn(),
+}));
+
+jest.mock("~/models/recruitment", () => ({
+  getRecruitmentGroupByUid: jest.fn(),
+  getRecruitmentGroupsByUidsStrict: jest.fn(),
+  normalizeRecruitmentGroupPeriod: jest.fn(),
+}));
+
+jest.mock("~/models/timeline-content.server", () => ({
+  getTimelineContents: jest.fn(),
+}));
+
+jest.mock("~/views/raid-content", () => ({
+  getUpcomingRaidContents: jest.fn(),
+}));
+
+const env = {} as Env;
+const mockedFetchRouteCached = fetchRouteCached as jest.MockedFunction<typeof fetchRouteCached>;
+const mockedGetRecruitmentGroupsByUidsStrict = getRecruitmentGroupsByUidsStrict as jest.MockedFunction<
+  typeof getRecruitmentGroupsByUidsStrict
+>;
+const mockedNormalizeRecruitmentGroupPeriod = normalizeRecruitmentGroupPeriod as jest.MockedFunction<
+  typeof normalizeRecruitmentGroupPeriod
+>;
+const mockedGetTimelineContents = getTimelineContents as jest.MockedFunction<typeof getTimelineContents>;
+const mockedGetUpcomingRaidContents = getUpcomingRaidContents as jest.MockedFunction<typeof getUpcomingRaidContents>;
+
+const recruitmentPeriod = {
+  startAt: "2030-01-11T00:00:00.000Z",
+  endAt: "2030-01-21T00:00:00.000Z",
+};
+
+const timelineContent = {
+  uid: "future-event",
+  name: "미래 이벤트",
+  nameI18n: {},
+  startAt: "2030-01-10T00:00:00.000Z",
+  endAt: "2030-01-20T00:00:00.000Z",
+  endless: false,
+  imageUrl: null,
+  videos: [],
+  contentType: "event",
+  runType: "first",
+  occurrence: null,
+  contentUid: "event-1",
+  shopContentUid: null,
+  recruitmentGroupUid: "group-a",
+  recruitmentStudentUids: null,
+  confirmed: true,
+  isSpoiler: false,
+  tags: [],
+  earnablePyroxene: null,
+  syncedAt: "2029-12-01T00:00:00.000Z",
+};
+
+const recruitmentGroup = {
+  uid: "group-a",
+  startAt: "2030-01-11T00:00:00.000Z",
+  endAt: "2030-01-21T00:00:00.000Z",
+  recruitments: [],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedGetTimelineContents.mockResolvedValue([timelineContent] as never);
+  mockedGetUpcomingRaidContents.mockResolvedValue([] as never);
+  mockedGetRecruitmentGroupsByUidsStrict.mockResolvedValue([recruitmentGroup] as never);
+  mockedNormalizeRecruitmentGroupPeriod.mockReturnValue(recruitmentPeriod);
+  mockedFetchRouteCached.mockImplementation(async (_env, _ctx, _key, fn) => fn());
+});
+
+describe("getFutureContents recruitment periods", () => {
+  it("caches normalized recruitment periods and uses the versioned futures key", async () => {
+    const result = await getFutureContents(env);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].recruitmentPeriod).toEqual(recruitmentPeriod);
+    expect(mockedFetchRouteCached).toHaveBeenCalledWith(
+      env,
+      undefined,
+      "route::futures::v3::all",
+      expect.any(Function),
+      false,
+    );
+    expect(mockedGetRecruitmentGroupsByUidsStrict).toHaveBeenCalledWith(env, ["group-a"], false);
+
+    const routeProducer = mockedFetchRouteCached.mock.calls[0][3];
+    const cachedShape = (await routeProducer()) as Array<{
+      recruitmentPeriod: typeof recruitmentPeriod;
+      recruitmentPeriodNotice?: unknown;
+    }>;
+    expect(cachedShape).toEqual([expect.objectContaining({ recruitmentPeriod })]);
+    expect(cachedShape[0]).not.toHaveProperty("recruitmentPeriodNotice");
+  });
+
+  it("propagates strict recruitment lookup failures instead of returning an empty result", async () => {
+    const error = new Error("BAQL unavailable");
+    mockedGetRecruitmentGroupsByUidsStrict.mockRejectedValue(error);
+
+    await expect(getFutureContents(env)).rejects.toBe(error);
+  });
+});


### PR DESCRIPTION
## Summary

Show a warning when a finite timeline content period differs from its linked BAQL recruitment-group period, so users can understand when recruitment ends before the content does and open the event details for the full schedule.

## Changes

- add a shared exact-instant period comparison and pre-end/ended notice copy
- exclude recruitment groups without an end time because no finite mismatch can be established
- carry normalized recruitment-group periods through the futures cache while keeping time-dependent copy outside the cache
- render clock-icon notices in the futures timeline and compact views, with a button that opens the event details
- show the recruitment start and end dates in the event-detail callout while leaving the schedule table unchanged
- use strict recruitment-group lookups for this feature so required BAQL failures are not treated as an empty state
- cover boundary conditions, cache shape, strict failures, placement, navigation, and exclusions with focused tests

## Verification

- [x] I verified the related behavior myself.
- [x] I ran `pnpm typecheck`, `pnpm exec biome check .`, and relevant tests when needed.
- [x] (If AI tools were used) The generated content was reviewed by a person.

Completed verification:

- `pnpm typecheck`
- `pnpm lint`
- 7 focused Jest suites (46 tests)
- actual desktop/mobile and light/dark rendering with current remote read-only data

Note: `pnpm exec biome check .` still reports pre-existing formatting errors in generated `.react-router/types` files; the repository's `pnpm lint` command passes.

## Related issues

Resolves MLLG-16
