### PR TITLE
Restore profile resource images (MLLG-24)

### DIFF
--- a/app/routes/$username.futures._components/FuturePlan.tsx
+++ b/app/routes/$username.futures._components/FuturePlan.tsx
@@ -17,10 +17,15 @@ import {
   roleLocale,
   schoolNameLocale,
 } from "~/locales/ko";
-import { equipmentImageUrl } from "~/models/assets";
 import type { NestedComment } from "~/models/content";
 import type { Role } from "~/models/content.d";
 import type { ActionData as CommentActionData } from "~/routes/api.contents.$uid.comments";
+
+const EQUIPMENT_CATEGORY_IMAGE_BASE_URL = "https://assets.mollulog.net/assets/images/equipments";
+
+export function equipmentCategoryImageUrl(category: string): string {
+  return `${EQUIPMENT_CATEGORY_IMAGE_BASE_URL}/${category}`;
+}
 
 type FuturePlanStudents = {
   uid: string;
@@ -215,7 +220,7 @@ export default function FuturePlan({ event, favoritedStudents, comments }: Futur
                       cardProps={[
                         ...resources.equipments.map((equipment) => ({
                           id: `equipment-${student.uid}-${equipment}`,
-                          imageUrl: equipmentImageUrl(equipment),
+                          imageUrl: equipmentCategoryImageUrl(equipment),
                         })),
                         ...resources.mainSkillItems.map((itemUid) => ({
                           id: `skillItem-${student.uid}-${itemUid}`,

--- a/test/app/routes/username.futures._components.test.ts
+++ b/test/app/routes/username.futures._components.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "@jest/globals";
+import { equipmentCategoryImageUrl } from "~/routes/$username.futures._components/FuturePlan";
+
+describe("FuturePlan equipment category image URLs", () => {
+  it.each(["hat", "bag", "shoes"])('uses the existing category asset path for "%s"', (category) => {
+    expect(equipmentCategoryImageUrl(category)).toBe(
+      `https://assets.mollulog.net/assets/images/equipments/${category}`,
+    );
+  });
+
+  it("does not turn a category into a numeric resource URL", () => {
+    expect(equipmentCategoryImageUrl("hat")).not.toContain("/images/resources/equipments/");
+    expect(equipmentCategoryImageUrl("hat")).not.toContain(".webp");
+  });
+});


### PR DESCRIPTION
## Summary

Restore broken required-equipment images on profile future-student lists by resolving equipment category keys through the established category asset endpoint.

## Changes

- Add a route-local equipment category image resolver for profile future plans.
- Keep the shared numeric equipment UID helper and skill-item image paths unchanged.
- Add focused regression coverage for representative category keys and the expected URL contract.

## Verification

- [x] I verified the related behavior myself.
- [ ] I ran `pnpm typecheck`, `pnpm exec biome check .`, and relevant tests when needed.
- [ ] (If AI tools were used) The generated content was reviewed by a person.

Executed checks:

- `mise exec -- pnpm exec jest --runInBand --runTestsByPath 'test/app/routes/username.futures._components.test.ts'` — 1 suite, 4 tests passed.
- `mise exec -- pnpm typecheck` — passed.
- `mise exec -- pnpm lint` — passed with pre-existing repository warnings and infos.
- Actual render at `/@<profile>/futures`, 390×844 viewport, dark theme, profile state with favorited students — mobile breakpoint active, no horizontal page overflow, 30/30 resource images loaded, including 18/18 equipment category images.
- Representative equipment category and skill-item CDN requests returned HTTP 200.

## Related issues

Resolves MLLG-24
